### PR TITLE
Labels for nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /node_modules
-#bundle.*
+bundle.*

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ var Animator = require('./src/Animator');
 var UrlState = require('./src/UrlState');
 var ActionQueue = require('./src/ActionQueue');
 var ResetButton = require('./src/ResetButton');
+var EditMode = require('./src/EditMode');
 
 require('./src/Logger').level = global.logLevel;
 
@@ -26,7 +27,11 @@ global.graph = new Graph(
   {
     actionQueue: actionQueue,
     adapter: adapter,
-    animator: new Animator({ actionQueue: actionQueue }),
+    editMode: new EditMode({
+      adapter: adapter,
+      animator: new Animator({ actionQueue: actionQueue }),
+      alternateInterval: 250,
+    }),
     state: new UrlState({
       baseUrl: window.location.protocol + "//" + window.location.host + window.location.pathname,
       setUrl: window.history.replaceState.bind(window.history, {}, ''),
@@ -37,7 +42,6 @@ global.graph = new Graph(
     nodeSize: nodeSize,
     edgeDistance: edgeDistance,
     nodeAreaFuzzFactor: 0.1,
-    editModeAlternateInterval: 250,
   });
 
 global.resetButton = new ResetButton({

--- a/main.js
+++ b/main.js
@@ -6,10 +6,40 @@ var UrlState = require('./src/UrlState');
 var ActionQueue = require('./src/ActionQueue');
 var ResetButton = require('./src/ResetButton');
 var EditMode = require('./src/EditMode');
+var NodeLabelSet = require('./src/NodeLabelSet');
+var ComponentManager = require('./src/ComponentManager');
 
 require('./src/Logger').level = global.logLevel;
 
+global.adapter = new GreulerAdapter(greuler);
+
 var actionQueue = new ActionQueue();
+var componentServices = {
+  actionQueue: actionQueue,
+};
+var componentManager = new ComponentManager({
+  actionQueue: actionQueue,
+  componentServices: componentServices,
+  document: document,
+});
+
+var state = new UrlState({
+  baseUrl: window.location.protocol + "//" + window.location.host + window.location.pathname,
+  setUrl: window.history.replaceState.bind(window.history, {}, ''),
+  urlSearchParams: new URLSearchParams(window.location.search),
+});
+
+var labelSet = new NodeLabelSet({
+  componentManager: componentManager,
+  state: state,
+});
+
+var editMode = new EditMode({
+  adapter: adapter,
+  animator: new Animator({ actionQueue: actionQueue }),
+  labelSet: labelSet,
+  alternateInterval: 250,
+});
 
 var horizontalPadding = 20;
 var width = Math.floor(((window.innerWidth > 0) ? window.innerWidth : screen.width) - (2 * horizontalPadding));
@@ -22,27 +52,21 @@ if (width < 1000) {
   edgeDistance = 200;
 }
 
-global.adapter = new GreulerAdapter(greuler);
-global.graph = new Graph(
+
+global.graph = new Graph(Object.assign(
   {
-    actionQueue: actionQueue,
     adapter: adapter,
-    editMode: new EditMode({
-      adapter: adapter,
-      animator: new Animator({ actionQueue: actionQueue }),
-      alternateInterval: 250,
-    }),
-    state: new UrlState({
-      baseUrl: window.location.protocol + "//" + window.location.host + window.location.pathname,
-      setUrl: window.history.replaceState.bind(window.history, {}, ''),
-      urlSearchParams: new URLSearchParams(window.location.search),
-    }),
+    editMode: editMode,
+    labelSet: labelSet,
+    state: state,
     width: width,
     height: height,
     nodeSize: nodeSize,
     edgeDistance: edgeDistance,
     nodeAreaFuzzFactor: 0.1,
-  });
+  },
+  componentServices
+));
 
 global.resetButton = new ResetButton({
   actionQueue: actionQueue,

--- a/src/Animator.js
+++ b/src/Animator.js
@@ -43,6 +43,11 @@ AlternatingAnimation.prototype = {
       }
     }).bind(this);
     execute();
+    return this;
+  },
+
+  stop: function() {
+    return this.asLongAs(function() { return false; });
   },
 };
 

--- a/src/BlockText.js
+++ b/src/BlockText.js
@@ -1,0 +1,14 @@
+var Component = require('./Component');
+
+function BlockText(opts) {
+  Component.apply(this, arguments);
+  this.text = opts && opts.text;
+}
+
+BlockText.prototype = Object.assign(new Component(), {
+  getGeneratedMarkup: function() {
+    return this.text && ('<p>'  + this.text + '</p>');
+  },
+});
+
+module.exports = BlockText;

--- a/src/BoundingBox.js
+++ b/src/BoundingBox.js
@@ -5,13 +5,11 @@ function BoundingBox(dimensions) {
 BoundingBox.prototype = {
 
   expandBy: function(factor) {
-    var width = this.dimensions.right - this.dimensions.left;
-    var height = this.dimensions.bottom - this.dimensions.top;
     return new BoundingBox({
-      left: this.dimensions.left - width*factor,
-      right: this.dimensions.right + width*factor,
-      top: this.dimensions.top - height*factor,
-      bottom: this.dimensions.bottom + width*factor,
+      left: this.dimensions.left - this.getWidth()*factor,
+      right: this.dimensions.right + this.getWidth()*factor,
+      top: this.dimensions.top - this.getHeight()*factor,
+      bottom: this.dimensions.bottom + this.getHeight()*factor,
     });
   },
 
@@ -28,6 +26,51 @@ BoundingBox.prototype = {
     return this.dimensions.left <= point.x && point.x <= this.dimensions.right &&
            this.dimensions.top <= point.y && point.y <= this.dimensions.bottom;
 
+  },
+
+  getCenter: function() {
+    return {
+      x: this.dimensions.left + this.getWidth() / 2,
+      y: this.dimensions.top + this.getHeight() / 2,
+    };
+  },
+
+  getTopLeft: function() {
+    return {
+      x: this.dimensions.left,
+      y: this.dimensions.top,
+    };
+  },
+
+
+  getTopRight: function() {
+    return {
+      x: this.dimensions.right,
+      y: this.dimensions.top,
+    };
+  },
+
+
+  getBottomLeft: function() {
+    return {
+      x: this.dimensions.left,
+      y: this.dimensions.bottom,
+    };
+  },
+
+  getBottomRight: function() {
+    return {
+      x: this.dimensions.right,
+      y: this.dimensions.bottom,
+    };
+  },
+
+  getWidth: function() {
+    return this.dimensions.right - this.dimensions.left;
+  },
+
+  getHeight: function() {
+    return this.dimensions.bottom - this.dimensions.top;
   },
 
 };

--- a/src/BoundingBox.js
+++ b/src/BoundingBox.js
@@ -1,5 +1,10 @@
 function BoundingBox(dimensions) {
-  this.dimensions = dimensions;
+  this.dimensions = dimensions || {
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+  };
 }
 
 BoundingBox.prototype = {

--- a/src/Component.js
+++ b/src/Component.js
@@ -22,15 +22,16 @@ function Component(options) {
   this.mouseDownCount = 0;
   this.mouseUpCount = 0;
   this.isInClickAndHold = false;
+  this.closeListeners = [];
 }
 
 Component.prototype = {
   handleClick: function() {},
   handleClickAndHold: function() {},
 
-
   attachTo: function(targetElement) {
     this._validateOptions();
+    this.element = targetElement;
     var lastDownEvent = null;
 
     targetElement.addEventListener('mouseup', (function(event) {
@@ -65,7 +66,19 @@ Component.prototype = {
       }).bind(this));
     }).bind(this));
 
+    if (this.getGeneratedMarkup()) {
+      targetElement.innerHTML = this.getGeneratedMarkup();
+    }
+
     this.doAttach(targetElement);
+  },
+
+  /**
+   * subclasses can override to indicate initial markup
+   * to be set on the target element
+   */
+  getGeneratedMarkup: function() {
+    return null;
   },
 
   /**
@@ -73,6 +86,18 @@ Component.prototype = {
    */
   doAttach: function(element) {
 
+  },
+
+  onClose: function(listener) {
+    this.closeListeners.push(listener);
+    return this;
+  },
+
+  close: function() {
+    this.closeListeners.forEach((function(f) {
+      f(this);
+    }).bind(this));
+    this.element.remove();
   },
 
   _validateOptions: function() {

--- a/src/Component.js
+++ b/src/Component.js
@@ -32,19 +32,18 @@ Component.prototype = {
   attachTo: function(targetElement) {
     this._validateOptions();
     this.element = targetElement;
-    var lastDownEvent = null;
 
     targetElement.addEventListener('mouseup', (function(event) {
       LOG.debug('mouseup', utils.normalizeEvent(event));
-      this.mouseTouchSwitch.exit('mouse', (function() {
-        this._handleMouseUp(lastDownEvent);
+      this.mouseTouchSwitch.exit('mouse', (function(modeState) {
+        this._handleMouseUp(modeState.lastDownEvent);
       }).bind(this));
     }).bind(this));
 
     targetElement.addEventListener('touchend', (function(event) {
       LOG.debug('touchend', utils.normalizeEvent(event));
-      this.mouseTouchSwitch.exit('touch', (function() {
-        this._handleMouseUp(lastDownEvent);
+      this.mouseTouchSwitch.exit('touch', (function(modeState) {
+        this._handleMouseUp(modeState.lastDownEvent);
       }).bind(this));
     }).bind(this));
 
@@ -52,17 +51,17 @@ Component.prototype = {
       event = utils.normalizeEvent(event);
       LOG.debug('mousedown', event);
       this.mouseTouchSwitch.enter('mouse', (function() {
-        lastDownEvent = event;
         this._handleMouseDown(event);
+        return { lastDownEvent: event };
       }).bind(this));
     }).bind(this));
 
     targetElement.addEventListener('touchstart', (function(event) {
-      event - utils.normalizeEvent(event);
+      event = utils.normalizeEvent(event);
       LOG.debug('touchstart', event);
       this.mouseTouchSwitch.enter('touch', (function() {
-        lastDownEvent = event;
         this._handleMouseDown(event);
+        return { lastDownEvent: event };
       }).bind(this));
     }).bind(this));
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -16,6 +16,7 @@ function Component(options) {
     this.mouseTouchSwitch = new ModeSwitch({
       actionQueue: this.actionQueue,
       timeout: 500,
+      name: 'mouseTouchSwitch',
     });
   }
 
@@ -97,6 +98,7 @@ Component.prototype = {
       f(this);
     }).bind(this));
     this.element.remove();
+    LOG.debug('closed component', this);
   },
 
   _validateOptions: function() {

--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -1,0 +1,42 @@
+var utils = require('./utils');
+var Position = require('./Position');
+var Component = require('./Component');
+
+function ComponentManager(options) {
+  this.document = options && options.document;
+  this.actionQueue = options && options.actionQueue;
+  this.componentServices = options && options.componentServices;
+}
+
+ComponentManager.prototype = {
+  insertComponent: function(options) {
+    options = Object.assign({
+      position: new Position({ topLeft: { x: 0, y: 0 }}),
+      pinTo: undefined,
+      class: Component,
+      constructorArgs: undefined,
+    }, options);
+
+    var component = new options.class(Object.assign(
+      {},
+      this.componentServices,
+      options.constructorArgs
+    ));
+
+    var element = this.document.createElement('div');
+    if (options.position) {
+      element.style = options.position.getStyle();
+    }
+    if (typeof options.pinTo === 'function') {
+      var positionTracker = this.actionQueue.periodically((function() {
+        element.style = options.pinTo().getStyle();
+      }).bind(this));
+      component.onClose(positionTracker.cancel.bind(positionTracker));
+    }
+    this.document.body.insertBefore(element, this.document.body.firstChild);
+    component.attachTo(element);
+    return component;
+  },
+};
+
+module.exports = ComponentManager;

--- a/src/ComponentManager.js
+++ b/src/ComponentManager.js
@@ -29,7 +29,10 @@ ComponentManager.prototype = {
     }
     if (typeof options.pinTo === 'function') {
       var positionTracker = this.actionQueue.periodically((function() {
-        element.style = options.pinTo().getStyle();
+        element.style = options.pinTo().getStyle({
+          width: element.offsetWidth,
+          height: element.offsetHeight,
+        });
       }).bind(this));
       component.onClose(positionTracker.cancel.bind(positionTracker));
     }

--- a/src/EditMode.js
+++ b/src/EditMode.js
@@ -1,0 +1,97 @@
+var ModeSwitch = require('./ModeSwitch');
+var colors = require('./colors');
+
+
+function EditMode(opts) {
+  this.adapter = opts && opts.adapter;
+  this.animator = opts && opts.animator;
+  this.alternateInterval = (opts && opts.alternateInterval) || 100;
+  this.modeSwitch = (opts && opts.modeSwitch) || new ModeSwitch();
+  this.modeSwitch.enter('display');
+}
+
+
+EditMode.prototype = {
+
+  activate: function(node) {
+    this._validate();
+    this.modeSwitch
+      .exit('display')
+      .exit('edit', this._cleanUpEditState.bind(this))
+      .enter('edit', (function() {
+        var otherNodes = this.adapter.getNodes(function(n) {
+          return n.id !== node.id;
+        });
+        var originalColors = otherNodes.reduce(function(accum, node) {
+          accum[node.id] = node.color;
+          return accum;
+        }, {});
+
+        var animation = this.animator
+          .alternate(
+            this._setNeon.bind(this, otherNodes),
+            this._setOriginalColors.bind(this, otherNodes, originalColors)
+          )
+          .every(this.alternateInterval)
+          .play();
+        return {
+          node: node,
+          animation: animation,
+          otherNodes: otherNodes,
+          originalColors: originalColors,
+        };
+      }).bind(this));
+  },
+
+  deactivate: function() {
+    this._validate();
+    this.modeSwitch
+      .exit('edit', this._cleanUpEditState.bind(this))
+      .enter('display');
+  },
+
+  perform: function(opts) {
+    opts = Object.assign({
+      ifActive: function() {},
+      ifNotActive: function() {},
+    }, opts);
+    this._validate();
+
+    this.modeSwitch.ifActive({
+      edit: function(editState) { opts.ifActive(editState.node); },
+      display: opts.ifNotActive,
+    });
+  },
+
+  _setNeon: function(otherNodes) {
+    otherNodes.forEach((function(n) {
+      this.adapter.setNodeColor(n, colors.NEON);
+    }).bind(this));
+  },
+
+  _setOriginalColors: function(otherNodes, originalColors) {
+    otherNodes.forEach((function(n) {
+      this.adapter.setNodeColor(n, originalColors[n.id]);
+    }).bind(this));
+  },
+
+  _cleanUpEditState: function(editState) {
+    editState.animation.stop();
+    this._setOriginalColors(editState.otherNodes, editState.originalColors);
+  },
+
+  _validate: function() {
+    if (!this.adapter) {
+      throw new Error('adapter is required');
+    }
+    if (!this.animator) {
+      throw new Error('animator is required');
+    }
+    if (!this.modeSwitch) {
+      throw new Error('modeSwitch is required');
+    }
+  }
+
+};
+
+module.exports = EditMode;

--- a/src/EditMode.js
+++ b/src/EditMode.js
@@ -6,6 +6,7 @@ function EditMode(opts) {
   this.adapter = opts && opts.adapter;
   this.animator = opts && opts.animator;
   this.alternateInterval = (opts && opts.alternateInterval) || 100;
+  this.labelSet = opts && opts.labelSet;
   this.modeSwitch = (opts && opts.modeSwitch) || new ModeSwitch();
   this.modeSwitch.enter('display');
 }
@@ -34,6 +35,8 @@ EditMode.prototype = {
           )
           .every(this.alternateInterval)
           .play();
+
+        this.labelSet.edit(node);
         return {
           node: node,
           animation: animation,
@@ -77,6 +80,7 @@ EditMode.prototype = {
 
   _cleanUpEditState: function(editState) {
     editState.animation.stop();
+    this.labelSet.display(editState.node);
     this._setOriginalColors(editState.otherNodes, editState.originalColors);
   },
 

--- a/src/EditMode.js
+++ b/src/EditMode.js
@@ -1,5 +1,6 @@
 var ModeSwitch = require('./ModeSwitch');
 var colors = require('./colors');
+var LOG = require('./Logger');
 
 
 function EditMode(opts) {
@@ -7,7 +8,9 @@ function EditMode(opts) {
   this.animator = opts && opts.animator;
   this.alternateInterval = (opts && opts.alternateInterval) || 100;
   this.labelSet = opts && opts.labelSet;
-  this.modeSwitch = (opts && opts.modeSwitch) || new ModeSwitch();
+  this.modeSwitch = (opts && opts.modeSwitch) || new ModeSwitch({
+    name: 'editMode',
+  });
   this.modeSwitch.enter('display');
 }
 
@@ -15,6 +18,7 @@ function EditMode(opts) {
 EditMode.prototype = {
 
   activate: function(node) {
+    LOG.info('EditMode: activating');
     this._validate();
     this.modeSwitch
       .exit('display')
@@ -37,20 +41,26 @@ EditMode.prototype = {
           .play();
 
         this.labelSet.edit(node);
-        return {
+
+        var editState = {
           node: node,
           animation: animation,
           otherNodes: otherNodes,
           originalColors: originalColors,
         };
+        LOG.debug('EditMode: activated', editState);
+        return editState;
       }).bind(this));
   },
 
   deactivate: function() {
+    LOG.debug('EditMode: deactvating');
     this._validate();
     this.modeSwitch
       .exit('edit', this._cleanUpEditState.bind(this))
-      .enter('display');
+      .enter('display', function() {
+        LOG.debug('EditMode: deactvated');
+      });
   },
 
   perform: function(opts) {
@@ -79,6 +89,7 @@ EditMode.prototype = {
   },
 
   _cleanUpEditState: function(editState) {
+    LOG.debug('cleaning up edit mode state', editState);
     editState.animation.stop();
     this.labelSet.display(editState.node);
     this._setOriginalColors(editState.otherNodes, editState.originalColors);

--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -1,0 +1,66 @@
+var ModeSwitch = require('./ModeSwitch');
+var BlockText = require('./BlockText');
+var TextBox = require('./TextBox');
+
+function EditableLabel(opts) {
+  if (opts) {
+    this.componentManager = opts.componentManager;
+    this.text = opts.text;
+    this.pinTo = opts.pinTo;
+    this.modeSwitch = new ModeSwitch();
+    this.onChange = opts.onChange || function() {};
+  }
+}
+
+EditableLabel.prototype = {
+  display: function() {
+    this._validate();
+
+    this.modeSwitch.exit('edit', (function() {
+      this.text = this.editComponent.getText();
+      this.editComponent.remove();
+      this.editComponent = null;
+    }).bind(this));
+
+    if (this.text) {
+      this.modeSwitch.enter('display', (function() {
+        this.displayComponent = this.componentManager.insertComponent({
+          class: BlockText,
+          constructorArgs: { text: this.text },
+          pinTo: this.pinTo,
+        });
+        this.onChange(this.text);
+      }).bind(this));
+    }
+    return this;
+  },
+
+  edit: function() {
+    this._validate();
+    this.modeSwitch.exit('display', (function() {
+      this.text = this.displayComponent.getText();
+      this.displayComponent.remove();
+      this.displayComponent = null;
+    }).bind(this));
+
+    this.modeSwitch.enter('edit', (function() {
+      this.editComponent = this.componentManager.insertComponent({
+        class: TextBox,
+        constructorArgs: { text: this.text },
+        pinTo: this.pinTo,
+      });
+    }).bind(this));
+    return this;
+  },
+
+  _validate: function() {
+    if(!this.componentManager) {
+      throw new Error('componentManager is required');
+    }
+    if(!this.modeSwitch) {
+      throw new Error('modeSwitch is required');
+    }
+  },
+};
+
+module.exports = EditableLabel;

--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -16,20 +16,20 @@ EditableLabel.prototype = {
   display: function() {
     this._validate();
 
-    this.modeSwitch.exit('edit', (function() {
-      this.text = this.editComponent.getText();
-      this.editComponent.remove();
-      this.editComponent = null;
+    this.modeSwitch.exit('edit', (function(editState) {
+      this.text = editState.component.getText();
+      editState.component.remove();
     }).bind(this));
 
     if (this.text) {
       this.modeSwitch.enter('display', (function() {
-        this.displayComponent = this.componentManager.insertComponent({
+        var component = this.componentManager.insertComponent({
           class: BlockText,
           constructorArgs: { text: this.text },
           pinTo: this.pinTo,
         });
         this.onChange(this.text);
+        return { component: component };
       }).bind(this));
     }
     return this;
@@ -37,18 +37,18 @@ EditableLabel.prototype = {
 
   edit: function() {
     this._validate();
-    this.modeSwitch.exit('display', (function() {
-      this.text = this.displayComponent.getText();
-      this.displayComponent.remove();
-      this.displayComponent = null;
+    this.modeSwitch.exit('display', (function(displayState) {
+      this.text = displayState.component.getText();
+      displayState.component.remove();
     }).bind(this));
 
     this.modeSwitch.enter('edit', (function() {
-      this.editComponent = this.componentManager.insertComponent({
+       var component = this.componentManager.insertComponent({
         class: TextBox,
         constructorArgs: { text: this.text },
         pinTo: this.pinTo,
       });
+      return { component: component };
     }).bind(this));
     return this;
   },

--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -22,7 +22,7 @@ EditableLabel.prototype = {
 
     this.modeSwitch.exit('edit', (function(editState) {
       this.text = editState.component.getText();
-      editState.component.remove();
+      editState.component.close();
       LOG.debug('EditableLabel: got text from input component', this.text);
     }).bind(this));
 
@@ -45,8 +45,7 @@ EditableLabel.prototype = {
     LOG.debug('EditableLabel: editing text', this.text);
     this._validate();
     this.modeSwitch.exit('display', (function(displayState) {
-      this.text = displayState.component.getText();
-      displayState.component.remove();
+      displayState.component.close();
       LOG.debug('EditableLabel: closed display component');
     }).bind(this));
 

--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -1,24 +1,29 @@
 var ModeSwitch = require('./ModeSwitch');
 var BlockText = require('./BlockText');
 var TextBox = require('./TextBox');
+var LOG = require('./Logger');
 
 function EditableLabel(opts) {
   if (opts) {
     this.componentManager = opts.componentManager;
     this.text = opts.text;
     this.pinTo = opts.pinTo;
-    this.modeSwitch = new ModeSwitch();
+    this.modeSwitch = new ModeSwitch({
+      name: 'EditableLabel({ text: \'' + this.text + '\'})'
+    });
     this.onChange = opts.onChange || function() {};
   }
 }
 
 EditableLabel.prototype = {
   display: function() {
+    LOG.debug('EditableLabel: displaying text', this.text);
     this._validate();
 
     this.modeSwitch.exit('edit', (function(editState) {
       this.text = editState.component.getText();
       editState.component.remove();
+      LOG.debug('EditableLabel: got text from input component', this.text);
     }).bind(this));
 
     if (this.text) {
@@ -29,6 +34,7 @@ EditableLabel.prototype = {
           pinTo: this.pinTo,
         });
         this.onChange(this.text);
+        LOG.debug('EditableLabel: displaying component with text', this.text);
         return { component: component };
       }).bind(this));
     }
@@ -36,10 +42,12 @@ EditableLabel.prototype = {
   },
 
   edit: function() {
+    LOG.debug('EditableLabel: editing text', this.text);
     this._validate();
     this.modeSwitch.exit('display', (function(displayState) {
       this.text = displayState.component.getText();
       displayState.component.remove();
+      LOG.debug('EditableLabel: closed display component');
     }).bind(this));
 
     this.modeSwitch.enter('edit', (function() {
@@ -48,6 +56,7 @@ EditableLabel.prototype = {
         constructorArgs: { text: this.text },
         pinTo: this.pinTo,
       });
+      LOG.debug('EditableLabel: opened edit component');
       return { component: component };
     }).bind(this));
     return this;

--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -63,4 +63,8 @@ EditableLabel.prototype = {
   },
 };
 
+EditableLabel.Factory = {
+  create: function(opts) { return new EditableLabel(opts); },
+};
+
 module.exports = EditableLabel;

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -18,6 +18,7 @@ function Graph(options) {
   if (options) {
     this.adapter = options.adapter;
     this.animator = options.animator;
+    this.labelSet = options.labelSet;
     this.editMode = options.editMode;
     this.state = options.state;
     this.width = options.width;
@@ -32,12 +33,13 @@ function Graph(options) {
 
 Graph.prototype = Object.assign(new Component(), {
   doAttach: function(targetElement) {
+    var persistedNodes = this.state.retrievePersistedNodes();
     this.adapter.initialize(
       targetElement,
       utils.optional({
         width: this.width,
         height: this.height,
-        nodes: this.state.retrievePersistedNodes().map((function(n) {
+        nodes: persistedNodes.map((function(n) {
           return utils.optional({
             id: n.id,
             color: n.color || COLOR_ORDER[0],
@@ -49,6 +51,13 @@ Graph.prototype = Object.assign(new Component(), {
         edgeDistance: this.edgeDistance,
       })
     );
+    var labelSetData = persistedNodes.map((function(n) {
+      return {
+        node: this.adapter.getNode(n.id),
+        label: n.label,
+      };
+    }).bind(this));
+    this.labelSet.initialize(labelSetData);
   },
 
   handleClick: function(event) {
@@ -138,6 +147,9 @@ Graph.prototype = Object.assign(new Component(), {
     }
     if (!this.state) {
       throw new Error('state is not present');
+    }
+    if (!this.labelSet) {
+      throw new Error('labelSet is not present');
     }
   },
 

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -109,7 +109,7 @@ Graph.prototype = Object.assign(new Component(), {
     var newColor = COLOR_ORDER[colorIndex];
     this.adapter.setNodeColor(node, newColor);
     this.colors[node.id] = colorIndex;
-    this.state.persistNodeColor(node.id, newColor);
+    this.state.persistNode({ id: node.id, color: newColor });
   },
 
   _createNode: function() {

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -135,9 +135,6 @@ Graph.prototype = Object.assign(new Component(), {
   },
 
   _enterEditMode: function(node) {
-    if (!this.animator) {
-      throw new Error('adapter is not present');
-    }
     this.currentlyEditedNode = node;
 
     this.editModeOtherNodes = this.adapter.getNodes(function(n) {

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -94,10 +94,6 @@ Graph.prototype = Object.assign(new Component(), {
         this.adapter.removeNode(node);
       }).bind(this));
 
-      this.state.retrievePersistedNodes().forEach((function(node) {
-        this.adapter.removeNode(node);
-      }).bind(this));
-
     }).bind(this));
 
     this._setInitialState();

--- a/src/GreulerAdapter.js
+++ b/src/GreulerAdapter.js
@@ -62,6 +62,10 @@ GreulerAdapter.prototype = {
     return this._getTargetNode(event, nodeAreaFuzzFactor) || graphelements.NONE;
   },
 
+  getNode: function(nodeId) {
+    return this.getNodes(function(n) { return n.id === nodeId; })[0];
+  },
+
   getNodes: function(filter) {
     filter = filter || function() { return true; };
     return this.graph.getNodesByFn(filter).map((function(node) {

--- a/src/GreulerAdapter.js
+++ b/src/GreulerAdapter.js
@@ -71,7 +71,7 @@ GreulerAdapter.prototype = {
         realNode: node,
         domElement: domElement,
         color: domElement.getAttribute('fill'),
-        boundingBox: this._getBoundingBox(node),
+        getCurrentBoundingBox: this._getBoundingBox.bind(this, node),
       });
     }).bind(this));
   },
@@ -112,8 +112,8 @@ GreulerAdapter.prototype = {
 
     if (matchingNodes && matchingNodes.length) {
       matchingNodes.sort(function(a, b) {
-        var distanceToA = utils.distance(a.boundingBox.getCenter(), point);
-        var distanceToB = utils.distance(b.boundingBox.getCenter(), point);
+        var distanceToA = utils.distance(a.getCenter(), point);
+        var distanceToB = utils.distance(b.getCenter(), point);
         return distanceToA - distanceToB;
       });
       return matchingNodes[0];

--- a/src/ModeSwitch.js
+++ b/src/ModeSwitch.js
@@ -1,19 +1,27 @@
-function ModeSwitch(options) {
-  this.actionQueue = options && options.actionQueue;
-  this.timeout = (options && options.timeout) || 0;
-  this.modeStates = (options && options.initialStates) || {};
+var LOG = require('./Logger');
+
+function ModeSwitch(opts) {
+  this.actionQueue = opts && opts.actionQueue;
+  this.timeout = (opts && opts.timeout) || 0;
+  this.modeStates = (opts && opts.initialStates) || {};
+  this.name = (opts && opts.name) || 'ModeSwitch';
   this.currentMode = null;
   this.resetModeFuture = null;
+  LOG.debug('Initialized ' + this.name, this);
 }
 
 ModeSwitch.prototype = {
   enter: function(mode, fn) {
     this._validate();
     if (this._isPermitted(mode)) {
+      LOG.debug(this.name + ': Entering \'' + mode + '\'', this);
       var state = (fn || function() {})();
       this.modeStates[mode] = state;
       this.currentMode = mode;
       this._cancelModeReset();
+    } else {
+      LOG.debug(this.name + ': Not entering \'' + mode + '\';'
+                + ' active mode is ' + this.currentMode, this);
     }
     return this;
   },
@@ -21,16 +29,26 @@ ModeSwitch.prototype = {
   exit: function(mode, fn) {
     this._validate();
     if(this._isActive(mode)) {
+      LOG.debug(this.name + ': Exiting ' + mode, this);
       (fn || function() {})(this.modeStates[mode]);
       this._scheduleModeReset();
+    } else {
+      LOG.debug(this.name + ': Not exiting \'' + mode + '\';'
+                + ' active mode is ' + this.currentMode, this);
     }
     return this;
   },
 
   ifActive: function(callbackObj) {
-    var callback = callbackObj[this.currentMode || 'default'];
-    var modeState = this.modeStates[this.currentMode || 'default'];
-    (callback || function(){})(modeState);
+    var activeMode = this.currentMode || 'default';
+    var callback = callbackObj[activeMode];
+    if (callback) {
+      LOG.debug(this.name + ': Found callback for active mode', activeMode, callbackObj);
+      var modeState = this.modeStates[this.currentMode || 'default'];
+      callback(modeState);
+    } else {
+      LOG.debug(this.name + ': No callback for active mode', activeMode, callbackObj);
+    }
     return this;
   },
 

--- a/src/ModeSwitch.js
+++ b/src/ModeSwitch.js
@@ -9,7 +9,7 @@ function ModeSwitch(options) {
 ModeSwitch.prototype = {
   enter: function(mode, fn) {
     this._validate();
-    if (this.isPermitted(mode)) {
+    if (this._isPermitted(mode)) {
       var state = (fn || function() {})();
       this.modeStates[mode] = state;
       this.currentMode = mode;
@@ -20,18 +20,25 @@ ModeSwitch.prototype = {
 
   exit: function(mode, fn) {
     this._validate();
-    if(this.isActive(mode)) {
+    if(this._isActive(mode)) {
       (fn || function() {})(this.modeStates[mode]);
       this._scheduleModeReset();
     }
     return this;
   },
 
-  isPermitted: function(mode) {
-    return !this.currentMode || this.isActive(mode);
+  ifActive: function(callbackObj) {
+    var callback = callbackObj[this.currentMode || 'default'];
+    var modeState = this.modeStates[this.currentMode || 'default'];
+    (callback || function(){})(modeState);
+    return this;
   },
 
-  isActive: function(mode) {
+  _isPermitted: function(mode) {
+    return !this.currentMode || this._isActive(mode);
+  },
+
+  _isActive: function(mode) {
     return this.currentMode === mode;
   },
 

--- a/src/ModeSwitch.js
+++ b/src/ModeSwitch.js
@@ -1,7 +1,7 @@
 function ModeSwitch(options) {
   if (options) {
     this.actionQueue = options.actionQueue;
-    this.timeout = options.timeout || 1;
+    this.timeout = options.timeout || 0;
   }
   this.currentMode = null;
   this.resetModeFuture = null;
@@ -38,15 +38,23 @@ ModeSwitch.prototype = {
   },
 
   _scheduleModeReset: function() {
-    this._cancelModeReset();
-    this.resetModeFuture = this.actionQueue.defer(this.timeout, (function() {
+    var resetFunction = (function() {
       this.currentMode = null;
-    }).bind(this));
+    }).bind(this);
+
+    this._cancelModeReset();
+    if (this.timeout) {
+      this.resetModeFuture = this.actionQueue.defer(
+        this.timeout, resetFunction
+      );
+    } else {
+      resetFunction();
+    }
   },
 
   _validate: function() {
-    if(!this.actionQueue) {
-      throw new Error('action queue is required');
+    if(this.timeout && !this.actionQueue) {
+      throw new Error('action queue is required if a timeout is specified');
     }
   },
 };

--- a/src/NodeLabelSet.js
+++ b/src/NodeLabelSet.js
@@ -1,0 +1,56 @@
+var Position = require('./Position');
+var EditableLabel = require('./EditableLabel');
+
+function NodeLabelSet(opts) {
+  this.componentManager = opts && opts.componentManager;
+  this.state = opts && opts.state;
+  this.editableLabelFactory = (opts && opts.editableLabelFactory) || EditableLabel.Factory;
+  this.labels = {};
+}
+
+NodeLabelSet.prototype = {
+
+  initialize: function(initialData) {
+    initialData
+      .filter(function(o) { return !!o.label; })
+      .forEach((function(o) {
+        this.labels[o.node.id] = this._createLabel(o.node, o.label).display();
+      }).bind(this));
+  },
+
+  edit: function(node) {
+    var label = this.labels[node.id] || this._createLabel(node);
+    label.edit();
+  },
+
+  display: function(node) {
+    var label = this.labels[node.id] || this._createLabel(node);
+    label.display();
+  },
+
+  _createLabel: function(node, label) {
+    return this.editableLabelFactory.create({
+      text: label,
+      componentManager: this.componentManager,
+      pinTo: function() {
+        return new Position({
+          bottomRight: node.getCurrentBoundingBox().getTopLeft(),
+        });
+      },
+      onChange: (function(text) {
+        this.state.persistNode({ id: node.id, label: text });
+      }).bind(this),
+    });
+  },
+
+  _validate: function() {
+    if (!this.componentManager) {
+      throw new Error('componentManager is required');
+    }
+    if (!this.state) {
+      throw new Error('state is required');
+    }
+  },
+};
+
+module.exports = NodeLabelSet;

--- a/src/NodeLabelSet.js
+++ b/src/NodeLabelSet.js
@@ -1,5 +1,6 @@
 var Position = require('./Position');
 var EditableLabel = require('./EditableLabel');
+var LOG = require('./Logger');
 
 function NodeLabelSet(opts) {
   this.componentManager = opts && opts.componentManager;
@@ -19,13 +20,25 @@ NodeLabelSet.prototype = {
   },
 
   edit: function(node) {
-    var label = this.labels[node.id] || this._createLabel(node);
-    label.edit();
+    LOG.debug('LabelSet: editing label for node ' + node.id);
+    this._getOrCreateLabel(node).edit();
   },
 
   display: function(node) {
-    var label = this.labels[node.id] || this._createLabel(node);
-    label.display();
+    LOG.debug('LabelSet: displaying label for node ' + node.id);
+    this._getOrCreateLabel(node).display();
+  },
+
+  _getOrCreateLabel: function(node) {
+    var label;
+    if (this.labels[node.id]) {
+      label = this.labels[node.id];
+      LOG.info('reusing existing label for node ' + node.id, label);
+    } else {
+      label = this._createLabel(node);
+      LOG.info('created new label for node ' + node.id, label);
+    }
+    return label;
   },
 
   _createLabel: function(node, label) {

--- a/src/NodeLabelSet.js
+++ b/src/NodeLabelSet.js
@@ -36,6 +36,7 @@ NodeLabelSet.prototype = {
       LOG.info('reusing existing label for node ' + node.id, label);
     } else {
       label = this._createLabel(node);
+      this.labels[node.id] = label;
       LOG.info('created new label for node ' + node.id, label);
     }
     return label;

--- a/src/Position.js
+++ b/src/Position.js
@@ -18,23 +18,28 @@ function Position(opts) {
 
 
 Position.prototype = {
-  getStyle: function() {
+  getStyle: function(opts) {
+    opts = Object.assign({
+      width: 0,
+      height: 0,
+    }, opts);
+
     if (this.topLeft) {
         return 'position: absolute;' +
         ' left: ' + this.topLeft.x + ';' +
         ' top: ' + this.topLeft.y + ';';
     } else if (this.topRight) {
       return 'position: absolute;' +
-        ' right: ' + this.topRight.x + ';' +
+        ' left: ' + (this.topRight.x - opts.width) + ';' +
         ' top: ' + this.topRight.y + ';';
     } else if (this.bottomLeft) {
       return 'position: absolute;' +
         ' left: ' + this.bottomLeft.x + ';' +
-        ' bottom: ' + this.bottomLeft.y + ';';
+        ' top: ' + (this.bottomLeft.y - opts.height) + ';';
     } else if (this.bottomRight) {
       return 'position: absolute;' +
-        ' right: ' + this.bottomRight.x + ';' +
-        ' bottom: ' + this.bottomRight.y + ';';
+        ' left: ' + (this.bottomRight.x  - opts.width)+ ';' +
+        ' top: ' + (this.bottomRight.y - opts.height) + ';';
     } else {
       throw new Error('invalid position object: ' + this);
     }

--- a/src/Position.js
+++ b/src/Position.js
@@ -1,0 +1,44 @@
+var utils = require('./utils');
+
+function Position(opts) {
+  /* opts -
+   * {
+    topLeft: { x: 0, y: 0 },
+    topRight: undefined,
+    bottomLeft: undefined,
+    bottomRight: undefined,
+    }
+   */
+  if (!utils.isOneValuedObject(opts)) {
+    throw new Error('invalid position object ' + opts);
+  }
+
+  Object.assign(this, opts);
+}
+
+
+Position.prototype = {
+  getStyle: function() {
+    if (this.topLeft) {
+        return 'position: absolute;' +
+        ' left: ' + this.topLeft.x + ';' +
+        ' top: ' + this.topLeft.y + ';';
+    } else if (this.topRight) {
+      return 'position: absolute;' +
+        ' right: ' + this.topRight.x + ';' +
+        ' top: ' + this.topRight.y + ';';
+    } else if (this.bottomLeft) {
+      return 'position: absolute;' +
+        ' left: ' + this.bottomLeft.x + ';' +
+        ' bottom: ' + this.bottomLeft.y + ';';
+    } else if (this.bottomRight) {
+      return 'position: absolute;' +
+        ' right: ' + this.bottomRight.x + ';' +
+        ' bottom: ' + this.bottomRight.y + ';';
+    } else {
+      throw new Error('invalid position object: ' + this);
+    }
+  },
+};
+
+module.exports = Position;

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -1,0 +1,20 @@
+var Component = require('./Component');
+
+function TextBox(options) {
+  Component.apply(this, arguments);
+  this.initialText = (options && options.text) || '';
+}
+
+TextBox.prototype = Object.assign(new Component(), {
+  getGeneratedMarkup: function() {
+    return '<input type="text"' +
+    ' value="' + this.initialText + '"' +
+    '></input>';
+  },
+
+  getText: function() {
+    return this.element.getElementsByTagName('input')[0].value;
+  },
+});
+
+module.exports = TextBox;

--- a/src/UrlState.js
+++ b/src/UrlState.js
@@ -3,6 +3,7 @@ var utils = require('./utils');
 NUM_NODES_PARAM = 'n'
 COLOR_PARAM_PREFIX = 'c_';
 EDGE_PARAM_PREFIX = 'e_';
+LABEL_PARAM_PREFIX = 'l_';
 
 function UrlState(options) {
   this.baseUrl = (options && options.baseUrl);
@@ -26,6 +27,10 @@ UrlState.prototype = {
 
     if (options.color) {
       this._setNodeColor(nodeId, options.color);
+    }
+
+    if (options.label) {
+      this._setNodeLabel(nodeId, options.label);
     }
 
     this._persistState();
@@ -53,9 +58,11 @@ UrlState.prototype = {
         var nodeColor = colorParams.find((function(param) {
           return this._isColor({ bit: nodeBit, colorKey: param });
         }).bind(this));
+        var label = this.urlSearchParams.get(LABEL_PARAM_PREFIX + i);
         nodes.push(utils.optional({
           id: i,
           color: (nodeColor && nodeColor.replace(COLOR_PARAM_PREFIX, '#')),
+          label: label && decodeURIComponent(label),
         }, { force: 'id' }));
       }
     }
@@ -77,6 +84,13 @@ UrlState.prototype = {
       return edges;
     }).bind(this))
     .reduce(function(a, b) { return a.concat(b); }, []);
+  },
+
+  _setNodeLabel: function(nodeId, label) {
+    this.urlSearchParams.set(
+      LABEL_PARAM_PREFIX + nodeId,
+      encodeURIComponent(label)
+    );
   },
 
   getUrl: function() {

--- a/src/UrlState.js
+++ b/src/UrlState.js
@@ -37,6 +37,19 @@ UrlState.prototype = {
     return nodeId;
   },
 
+  retrieveNode: function(nodeId) {
+    var nodeBit = this._idToBit(nodeId);
+    var nodeColor = this._getColorKeys().find((function(param) {
+      return this._isColor({ bit: nodeBit, colorKey: param });
+    }).bind(this));
+    var label = this.urlSearchParams.get(LABEL_PARAM_PREFIX + nodeId);
+    return utils.optional({
+      id: nodeId,
+      color: (nodeColor && nodeColor.replace(COLOR_PARAM_PREFIX, '#')),
+      label: label && decodeURIComponent(label),
+    }, { force: 'id' });
+  },
+
   persistEdge: function(sourceId, targetId) {
     var param = EDGE_PARAM_PREFIX + sourceId;
     var bitmask;
@@ -52,18 +65,8 @@ UrlState.prototype = {
   retrievePersistedNodes: function() {
     var nodes = [];
     if (this.urlSearchParams.has(NUM_NODES_PARAM)) {
-      var colorParams = this._getColorKeys();
       for (var i = 0 ; i < this.urlSearchParams.get(NUM_NODES_PARAM); i++) {
-        var nodeBit = this._idToBit(i);
-        var nodeColor = colorParams.find((function(param) {
-          return this._isColor({ bit: nodeBit, colorKey: param });
-        }).bind(this));
-        var label = this.urlSearchParams.get(LABEL_PARAM_PREFIX + i);
-        nodes.push(utils.optional({
-          id: i,
-          color: (nodeColor && nodeColor.replace(COLOR_PARAM_PREFIX, '#')),
-          label: label && decodeURIComponent(label),
-        }, { force: 'id' }));
+        nodes.push(this.retrieveNode(i));
       }
     }
     return nodes;

--- a/src/UrlState.js
+++ b/src/UrlState.js
@@ -15,27 +15,21 @@ UrlState.prototype = {
    * Perist a node and return its id
    */
   persistNode: function(options) {
-    var nodeId = this._getNumNodes();
-    this.urlSearchParams.set(NUM_NODES_PARAM, nodeId + 1);
-    this._persistState();
-    if (options && options.color) {
-      this.persistNodeColor(nodeId, options.color);
+    options = options || {};
+    var nodeId;
+    if (options.id) {
+      nodeId = options.id;
+    } else {
+      nodeId = this._getNumNodes();
+      this.urlSearchParams.set(NUM_NODES_PARAM, nodeId + 1);
     }
 
-    return nodeId;
-  },
+    if (options.color) {
+      this._setNodeColor(nodeId, options.color);
+    }
 
-  persistNodeColor: function(nodeId, color) {
-    var bit = this._idToBit(nodeId);
-
-    this._getColorKeys().forEach((function(key) {
-      if (this._isColor({ bit: bit, colorKey: key })) {
-        this._removeColor({ bit: bit, colorKey: key });
-      }
-    }).bind(this));
-
-    this._setColor({ bit: bit, color: color });
     this._persistState();
+    return nodeId;
   },
 
   persistEdge: function(sourceId, targetId) {
@@ -196,6 +190,19 @@ UrlState.prototype = {
       return 0;
     }
   },
+
+  _setNodeColor: function(nodeId, color) {
+    var bit = this._idToBit(nodeId);
+
+    this._getColorKeys().forEach((function(key) {
+      if (this._isColor({ bit: bit, colorKey: key })) {
+        this._removeColor({ bit: bit, colorKey: key });
+      }
+    }).bind(this));
+
+    this._setColor({ bit: bit, color: color });
+  },
+
 
   _persistState: function() {
     this.setUrl(this.getUrl());

--- a/src/graphelements.js
+++ b/src/graphelements.js
@@ -19,12 +19,32 @@ function Node(options) {
   if (options) {
     this.realNode = options.realNode;
     this.color = options.color;
-    this.boundingBox = options.boundingBox;
+    this.getCurrentBoundingBox = options.getCurrentBoundingBox;
   }
 }
 
 Node.prototype = Object.assign(new GraphElement(), {
   isNode: function() { return true; },
+
+  getCenter: function() {
+    return this.getCurrentBoundingBox().getCenter();
+  },
+
+  getTopLeft: function() {
+    return this.getCurrentBoundingBox().getTopLeft();
+  },
+
+  getTopRight: function() {
+    return this.getCurrentBoundingBox().getTopRight();
+  },
+
+  getBottomLeft: function() {
+    return this.getCurrentBoundingBox().getBottomLeft();
+  },
+
+  getBottomRight: function() {
+    return this.getCurrentBoundingBox().getBottomRight();
+  },
 });
 
 

--- a/src/graphelements.js
+++ b/src/graphelements.js
@@ -19,6 +19,7 @@ function Node(options) {
   if (options) {
     this.realNode = options.realNode;
     this.color = options.color;
+    this.boundingBox = options.boundingBox;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,8 +47,20 @@ function normalizeEvent(event) {
   }
 }
 
+function isOneValuedObject(obj) {
+  if (obj && (typeof obj === 'object') && !Array.isArray(obj)) {
+    var presentKeys = Object.keys(obj)
+      .filter(function(k) { return !!obj[k]; });
+    return presentKeys.length === 1
+  } else {
+    return false;
+  }
+
+}
+
 module.exports = {
   distance: distance,
   optional: optional,
   normalizeEvent: normalizeEvent,
+  isOneValuedObject: isOneValuedObject,
 };

--- a/test/ActionQueue-test.js
+++ b/test/ActionQueue-test.js
@@ -4,13 +4,16 @@ describe('ActionQueue', function() {
   var setTimeout;
   var clearTimeout;
   var actionQueue;
+  var actionInterval;
 
   beforeEach(function() {
     setTimeout = createSpy();
     clearTimeout = createSpy();
+    actionInterval = 10;
     actionQueue = new ActionQueue({
       setTimeout: setTimeout,
       clearTimeout: clearTimeout,
+      actionInterval: actionInterval,
     });
   });
 
@@ -40,4 +43,68 @@ describe('ActionQueue', function() {
     });
   });
 
+  describe('periodically', function() {
+    it('starts a queue of periodic actions if one has not been started yet', function() {
+      var fn = createSpy();
+      actionQueue.periodically(fn);
+
+      expect(fn.calls.length).toEqual(1);
+      expect(setTimeout.calls.length).toEqual(1);
+
+      setTimeout.calls[0].arguments[0]();
+      expect(fn.calls.length).toEqual(2);
+      expect(setTimeout.calls.length).toEqual(2);
+
+
+      setTimeout.calls[1].arguments[0]();
+      expect(fn.calls.length).toEqual(3);
+      expect(setTimeout.calls.length).toEqual(3);
+    });
+
+    it('adds new actions to the existing queue', function() {
+      var fn1 = createSpy();
+      var fn2 = createSpy();
+      actionQueue.periodically(fn1);
+      actionQueue.periodically(fn2);
+
+      expect(fn1.calls.length).toEqual(1);
+      expect(fn2.calls.length).toEqual(0);
+      expect(setTimeout.calls.length).toEqual(1);
+
+      setTimeout.calls[0].arguments[0]();
+      expect(fn1.calls.length).toEqual(2);
+      expect(fn2.calls.length).toEqual(1);
+      expect(setTimeout.calls.length).toEqual(2);
+
+
+      setTimeout.calls[1].arguments[0]();
+      expect(fn1.calls.length).toEqual(3);
+      expect(fn2.calls.length).toEqual(2);
+      expect(setTimeout.calls.length).toEqual(3);
+    });
+
+    it('returns objects that can cancel themselves', function() {
+      var fn1 = createSpy();
+      var fn2 = createSpy();
+      var tracker1 = actionQueue.periodically(fn1);
+      var tracker2 = actionQueue.periodically(fn2);
+
+      expect(fn1.calls.length).toEqual(1);
+      expect(fn2.calls.length).toEqual(0);
+      expect(setTimeout.calls.length).toEqual(1);
+
+      setTimeout.calls[0].arguments[0]();
+      expect(fn1.calls.length).toEqual(2);
+      expect(fn2.calls.length).toEqual(1);
+      expect(setTimeout.calls.length).toEqual(2);
+
+      tracker2.cancel();
+
+
+      setTimeout.calls[1].arguments[0]();
+      expect(fn1.calls.length).toEqual(3);
+      expect(fn2.calls.length).toEqual(1);
+      expect(setTimeout.calls.length).toEqual(3);
+    });
+  });
 });

--- a/test/Animator-test.js
+++ b/test/Animator-test.js
@@ -89,6 +89,28 @@ describe('Animator', function() {
       expect(f1).toNotHaveBeenCalled();
     });
 
+    it('stops when told to', function() {
+      var f1 = createSpy();
+
+      var animation = animator.alternate(f1).every(100).play();
+
+      expect(f1).toHaveBeenCalled();
+
+      f1.reset();
+      actionQueue.step(100);
+
+      expect(f1).toHaveBeenCalled();
+
+      f1.reset();
+      animation.stop();
+      actionQueue.step(100);
+
+      expect(f1).toNotHaveBeenCalled();
+
+      actionQueue.step(100);
+      expect(f1).toNotHaveBeenCalled();
+    });
+
     it('does nothing if the predicate is false immediately', function() {
       var f1 = createSpy();
       var predicate = createSpy().andReturn(false);

--- a/test/BlockText-test.js
+++ b/test/BlockText-test.js
@@ -1,0 +1,8 @@
+var BlockText = require('../src/BlockText');
+
+describe('BlockText', function() {
+  it('displays a p tag', function() {
+    var component = new BlockText({ text: 'hello' });
+    expect(component.getGeneratedMarkup()).toEqual('<p>hello</p>');
+  });
+});

--- a/test/BoundingBox-test.js
+++ b/test/BoundingBox-test.js
@@ -1,11 +1,14 @@
 var BoundingBox = require('../src/BoundingBox');
 
 describe('BoundingBox', function() {
-  var box = new BoundingBox({
-    left: 10,
-    right: 20,
-    top: 40,
-    bottom: 50,
+  var box;
+  beforeEach(function() {
+    box = new BoundingBox({
+      left: 10,
+      right: 20,
+      top: 40,
+      bottom: 50,
+    });
   });
 
   describe('contains', function() {
@@ -78,19 +81,19 @@ describe('BoundingBox', function() {
 
   describe('getTopRight', function() {
     it('returns a point in the top right of the box', function() {
-      expect(box.getTopLeft()).toEqual({ x: 20, y: 40 });
+      expect(box.getTopRight()).toEqual({ x: 20, y: 40 });
     });
   });
 
   describe('getBottomLeft', function() {
     it('returns a point in the bottom left of the box', function() {
-      expect(box.getTopLeft()).toEqual({ x: 10, y: 50 });
+      expect(box.getBottomLeft()).toEqual({ x: 10, y: 50 });
     });
   });
 
   describe('getBottomRight', function() {
     it('returns a point in the top left of the box', function() {
-      expect(box.getTopLeft()).toEqual({ x: 20, y: 50 });
+      expect(box.getBottomRight()).toEqual({ x: 20, y: 50 });
     });
   });
 });

--- a/test/BoundingBox-test.js
+++ b/test/BoundingBox-test.js
@@ -51,4 +51,46 @@ describe('BoundingBox', function() {
       expect(expanded.contains({ x: 10, y: 51 })).toBe(true);
     });
   });
+
+  describe('getWidth', function() {
+    it('returns the width of the box', function() {
+      expect(box.getWidth()).toBe(10);
+    });
+  });
+
+  describe('getHeight', function() {
+    it('returns the height of the box', function() {
+      box = new BoundingBox({
+        left: 0,
+        right: 10,
+        top: 10,
+        bottom: 400,
+      });
+      expect(box.getHeight()).toBe(390);
+    });
+  });
+
+  describe('getTopLeft', function() {
+    it('returns a point in the top left of the box', function() {
+      expect(box.getTopLeft()).toEqual({ x: 10, y: 40 });
+    });
+  });
+
+  describe('getTopRight', function() {
+    it('returns a point in the top right of the box', function() {
+      expect(box.getTopLeft()).toEqual({ x: 20, y: 40 });
+    });
+  });
+
+  describe('getBottomLeft', function() {
+    it('returns a point in the bottom left of the box', function() {
+      expect(box.getTopLeft()).toEqual({ x: 10, y: 50 });
+    });
+  });
+
+  describe('getBottomRight', function() {
+    it('returns a point in the top left of the box', function() {
+      expect(box.getTopLeft()).toEqual({ x: 20, y: 50 });
+    });
+  });
 });

--- a/test/Component-test.js
+++ b/test/Component-test.js
@@ -126,4 +126,29 @@ describe('Component', function() {
       expect(component.handleClick).toNotHaveBeenCalled();
     });
   });
+
+  describe('close', function() {
+    beforeEach(function() {
+      component.attachTo(element);
+    });
+
+    it('removes the dom node', function() {
+      expect(element.remove).toNotHaveBeenCalled();
+      component.close();
+      expect(element.remove).toHaveBeenCalled();
+    });
+
+    it('calls all the close listeners', function() {
+      var l1 = createSpy();
+      var l2 = createSpy();
+      component.onClose(l1).onClose(l2);
+      expect(l1).toNotHaveBeenCalled();
+      expect(l2).toNotHaveBeenCalled();
+
+      component.close();
+
+      expect(l1).toHaveBeenCalledWith(component);
+      expect(l2).toHaveBeenCalledWith(component);
+    });
+  });
 });

--- a/test/ComponentManager-test.js
+++ b/test/ComponentManager-test.js
@@ -1,0 +1,114 @@
+var ComponentManager = require('../src/ComponentManager');
+var MockActionQueue = require('./utils/MockActionQueue');
+
+describe('ComponentManager', function() {
+  var componentManager;
+  var actionQueue;
+  var document;
+  var body;
+  var element;
+  var componentServices;
+  function ComponentClass(opts) {
+    this.constructorArgs = opts;
+    this.attachTo = createSpy();
+    this.onClose = createSpy();
+  }
+
+  beforeEach(function() {
+    body = createSpyObjectWith('insertBefore', 'firstChild');
+    element = new MockDomNode();
+    document = createSpyObjectWith({
+      'createElement.returnValue': element,
+      body: body,
+    });
+    actionQueue = new MockActionQueue();
+    componentServices = { a: 'b', c: 'd' };
+
+    componentManager = new ComponentManager({
+      document: document,
+      actionQueue: actionQueue,
+      componentServices: componentServices,
+    });
+  });
+
+  describe('insertComponent', function() {
+    it('creates a new component and attaches the component', function() {
+      var component = componentManager.insertComponent({
+        class: ComponentClass,
+        constructorArgs: { hello: 'world' },
+      });
+      expect(document.createElement).toHaveBeenCalledWith('div');
+      expect(body.insertBefore).toHaveBeenCalledWith(element, body.firstChild);
+      expect(component.attachTo).toHaveBeenCalledWith(element);
+      expect(component.constructorArgs).toEqual({
+        a: 'b',
+        c: 'd',
+        hello: 'world',
+      });
+      expect(componentServices).toEqual({
+        a: 'b',
+        c: 'd',
+      });
+    });
+
+    it('sets the position on the element', function() {
+      var position = createSpyObjectWith({
+        'getStyle.returnValue': 'foobar',
+      });
+
+      componentManager.insertComponent({
+        class: ComponentClass,
+        position: position,
+      });
+      expect(element.style).toEqual('foobar');
+    });
+
+    it('pins the element to the result of the supplied function', function() {
+      var n = 0;
+      var p1 = createSpyObjectWith({'getStyle.returnValue': 'position1'});
+      var p2 = createSpyObjectWith({'getStyle.returnValue': 'position2'});
+      var p3 = createSpyObjectWith({'getStyle.returnValue': 'position3'});
+      var pinTo = createSpy().andCall(function() {
+        return [p1, p2, p3][(n++)%3];
+      });
+
+      componentManager.insertComponent({
+        class: ComponentClass,
+        pinTo: pinTo,
+      });
+
+      actionQueue.step(actionQueue.mainQueueInterval);
+      expect(element.style).toEqual('position1');
+
+      actionQueue.step(actionQueue.mainQueueInterval);
+      expect(element.style).toEqual('position2');
+
+      actionQueue.step(actionQueue.mainQueueInterval);
+      expect(element.style).toEqual('position3');
+
+      expect(pinTo.calls.length).toBe(3);
+    });
+
+    it('cancels the position tracking when the component is closed', function() {
+      var pinTo = createSpy().andReturn(
+        createSpyObjectWith({ 'getStyle.returnValue': 'p1' })
+      );
+
+      var component = componentManager.insertComponent({
+        class: ComponentClass,
+        pinTo: pinTo,
+      });
+
+      expect(component.onClose).toHaveBeenCalled();
+
+      actionQueue.step(actionQueue.mainQueueInterval);
+      expect(element.style).toEqual('p1');
+
+      component.onClose.calls[0].arguments[0]();
+
+      actionQueue.step(actionQueue.mainQueueInterval);
+
+      expect(pinTo.calls.length).toBe(1);
+    });
+  });
+});

--- a/test/ComponentManager-test.js
+++ b/test/ComponentManager-test.js
@@ -16,7 +16,10 @@ describe('ComponentManager', function() {
 
   beforeEach(function() {
     body = createSpyObjectWith('insertBefore', 'firstChild');
-    element = new MockDomNode();
+    element = new MockDomNode({
+      'offsetWidth': 123,
+      'offsetHeight': 456,
+    });
     document = createSpyObjectWith({
       'createElement.returnValue': element,
       body: body,
@@ -79,12 +82,24 @@ describe('ComponentManager', function() {
 
       actionQueue.step(actionQueue.mainQueueInterval);
       expect(element.style).toEqual('position1');
+      expect(p1.getStyle).toHaveBeenCalledWith({
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+      });
 
       actionQueue.step(actionQueue.mainQueueInterval);
       expect(element.style).toEqual('position2');
+      expect(p2.getStyle).toHaveBeenCalledWith({
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+      });
 
       actionQueue.step(actionQueue.mainQueueInterval);
       expect(element.style).toEqual('position3');
+      expect(p3.getStyle).toHaveBeenCalledWith({
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+      });
 
       expect(pinTo.calls.length).toBe(3);
     });

--- a/test/EditMode-test.js
+++ b/test/EditMode-test.js
@@ -8,6 +8,7 @@ describe('EditMode', function() {
   var animator;
   var animation;
   var editMode;
+  var labelSet;
   var alternateInterval = 456;
 
   beforeEach(function() {
@@ -23,14 +24,25 @@ describe('EditMode', function() {
     animator = createSpyObjectWith({
       'alternate.returnValue': animation,
     });
+
+    labelSet = createSpyObjectWith('display', 'edit');
+
     editMode = new EditMode({
       adapter: adapter,
       animator: animator,
+      labelSet: labelSet,
       alternateInterval: alternateInterval,
     });
   });
 
   describe('activate', function() {
+
+    it('edits the node label', function() {
+      var node = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      adapter.getNodes.andReturn([]);
+      editMode.activate(node);
+      expect(labelSet.edit).toHaveBeenCalledWith(node);
+    });
 
     it('animates the other nodes', function() {
       var otherNode1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
@@ -86,6 +98,7 @@ describe('EditMode', function() {
       expect(adapter.setNodeColor).toHaveBeenCalledWith(node2, '#FFFF00');
       expect(adapter.setNodeColor).toHaveBeenCalledWith(node3, '#FF00FF');
       expect(adapter.setNodeColor.calls.length).toBe(2);
+      expect(labelSet.display).toHaveBeenCalledWith(node1);
     });
   });
 
@@ -104,6 +117,7 @@ describe('EditMode', function() {
       expect(adapter.setNodeColor).toHaveBeenCalledWith(node2, '#FFFF00');
       expect(adapter.setNodeColor).toHaveBeenCalledWith(node3, '#FF00FF');
       expect(adapter.setNodeColor.calls.length).toBe(2);
+      expect(labelSet.display).toHaveBeenCalledWith(node1);
     });
   });
 

--- a/test/EditMode-test.js
+++ b/test/EditMode-test.js
@@ -1,0 +1,155 @@
+var EditMode = require('../src/EditMode');
+var graphelements = require('../src/graphelements');
+var colors = require('../src/colors');
+
+describe('EditMode', function() {
+
+  var adapter;
+  var animator;
+  var animation;
+  var editMode;
+  var alternateInterval = 456;
+
+  beforeEach(function() {
+    adapter = createSpyObjectWith(
+      'getNodes',
+      'setNodeColor'
+    );
+    animation = createSpyObjectWith(
+      { 'every.returnValue': 'this' },
+      { 'play.returnValue': 'this' },
+      'stop'
+    );
+    animator = createSpyObjectWith({
+      'alternate.returnValue': animation,
+    });
+    editMode = new EditMode({
+      adapter: adapter,
+      animator: animator,
+      alternateInterval: alternateInterval,
+    });
+  });
+
+  describe('activate', function() {
+
+    it('animates the other nodes', function() {
+      var otherNode1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var otherNode2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var otherNode3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      adapter.getNodes.andReturn([
+        otherNode1,
+        otherNode2,
+        otherNode3,
+      ]);
+
+      editMode.activate(new graphelements.Node({ id: 0 }));
+      expect(adapter.getNodes).toHaveBeenCalledWith(matchers.functionThatReturns(
+        { input: { id: 0 }, output: false },
+        { input: otherNode1, output: true },
+        { input: otherNode2, output: true },
+        { input: otherNode3, output: true }
+      ));
+      expect(animator.alternate).toHaveBeenCalled();
+      expect(animation.every).toHaveBeenCalledWith(alternateInterval);
+      expect(animation.play).toHaveBeenCalled();
+      var setNeonFunc = animator.alternate.calls[0].arguments[0];
+      var setOriginalColorFunc = animator.alternate.calls[0].arguments[1];
+      expect(adapter.setNodeColor).toNotHaveBeenCalled();
+
+      setNeonFunc();
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode1, colors.NEON);
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode2, colors.NEON);
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode3, colors.NEON);
+      expect(adapter.setNodeColor.calls.length).toBe(3);
+
+      adapter.setNodeColor.reset();
+      setOriginalColorFunc();
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode1, '#FFFFFF');
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode2, '#FFFF00');
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(otherNode3, '#FF00FF');
+      expect(adapter.setNodeColor.calls.length).toBe(3);
+    });
+
+    it('cleans up state if was previously active', function() {
+      var node1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var node2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var node3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      adapter.getNodes.andReturn([ node2, node3 ]);
+
+      editMode.activate(node1);
+
+      adapter.getNodes.andReturn([ node1, node3 ]);
+
+      editMode.activate(node2);
+
+      expect(animation.stop).toHaveBeenCalled();
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(node2, '#FFFF00');
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(node3, '#FF00FF');
+      expect(adapter.setNodeColor.calls.length).toBe(2);
+    });
+  });
+
+  describe('deactivate', function() {
+    it('cleans up edit state', function() {
+      var node1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var node2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var node3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      adapter.getNodes.andReturn([ node2, node3 ]);
+
+      editMode.activate(node1);
+
+      editMode.deactivate();
+
+      expect(animation.stop).toHaveBeenCalled();
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(node2, '#FFFF00');
+      expect(adapter.setNodeColor).toHaveBeenCalledWith(node3, '#FF00FF');
+      expect(adapter.setNodeColor.calls.length).toBe(2);
+    });
+  });
+
+  describe('perform', function() {
+    it('passes the node to the ifActive function if it is active', function() {
+      var node1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var node2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var node3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      var ifActive = createSpy();
+      var ifNotActive = createSpy();
+      adapter.getNodes.andReturn([ node2, node3 ]);
+
+      editMode.activate(node1);
+
+      editMode.perform({ ifActive: ifActive, ifNotActive: ifNotActive });
+      expect(ifActive).toHaveBeenCalledWith(node1);
+      expect(ifNotActive).toNotHaveBeenCalled();
+    });
+
+    it('calls the ifNotActive function if it has not been activated', function() {
+      var node1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var node2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var node3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      var ifActive = createSpy();
+      var ifNotActive = createSpy();
+      adapter.getNodes.andReturn([ node2, node3 ]);
+
+      editMode.perform({ ifActive: ifActive, ifNotActive: ifNotActive });
+      expect(ifActive).toNotHaveBeenCalled();
+      expect(ifNotActive).toHaveBeenCalled();
+    });
+
+    it('calls the ifNotActive function if it has been deactivated', function() {
+      var node1 = new graphelements.Node({ id: 1, color: '#FFFFFF' });
+      var node2 = new graphelements.Node({ id: 2, color: '#FFFF00' });
+      var node3 = new graphelements.Node({ id: 3, color: '#FF00FF' });
+      var ifActive = createSpy();
+      var ifNotActive = createSpy();
+      adapter.getNodes.andReturn([ node2, node3 ]);
+
+      editMode.activate(node1);
+      editMode.deactivate();
+
+      editMode.perform({ ifActive: ifActive, ifNotActive: ifNotActive });
+      expect(ifActive).toNotHaveBeenCalled();
+      expect(ifNotActive).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/EditableLabel-test.js
+++ b/test/EditableLabel-test.js
@@ -1,0 +1,66 @@
+var EditableLabel = require('../src/EditableLabel');
+var BlockText = require('../src/BlockText');
+var TextBox = require('../src/TextBox');
+
+describe('EditableLabel', function() {
+
+  var componentManager;
+  var pinTo;
+  var onChange;
+  var editableLabel;
+
+  beforeEach(function() {
+    componentManager = createSpyObjectWith('insertComponent');
+    pinTo = createSpy();
+    onChange = createSpy();
+    editableLabel = new EditableLabel({
+      componentManager: componentManager,
+      pinTo: pinTo,
+      onChange: onChange,
+    });
+  });
+
+  describe('display', function() {
+    it('does nothing if the label has no text', function() {
+      editableLabel.text = null;
+      editableLabel.display();
+      expect(componentManager.insertComponent).toNotHaveBeenCalled();
+    });
+
+    it('inserts a BlockText component if the label has text', function() {
+      editableLabel.text = 'hello';
+      editableLabel.display();
+      expect(componentManager.insertComponent).toHaveBeenCalledWith({
+        class: BlockText,
+        constructorArgs: { text: 'hello' },
+        pinTo: pinTo,
+      });
+    });
+
+    it('takes the text from edit component and displays it', function() {
+      var editComponent = createSpyObjectWith('getText', 'remove');
+      editComponent.getText.andReturn('edited text');
+      componentManager.insertComponent.andReturn(editComponent);
+      editableLabel.edit().display();
+      expect(componentManager.insertComponent).toHaveBeenCalledWith({
+        class: BlockText,
+        constructorArgs: { text: 'edited text' },
+        pinTo: pinTo,
+      });
+      expect(editComponent.remove).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith('edited text');
+    });
+  });
+
+  describe('edit', function() {
+    it('inserts a TextBox component with the text on the label', function() {
+      editableLabel.text = 'foobar';
+      editableLabel.edit();
+      expect(componentManager.insertComponent).toHaveBeenCalledWith({
+        class: TextBox,
+        constructorArgs: { text: 'foobar' },
+        pinTo: pinTo,
+      });
+    });
+  });
+});

--- a/test/EditableLabel-test.js
+++ b/test/EditableLabel-test.js
@@ -38,7 +38,7 @@ describe('EditableLabel', function() {
     });
 
     it('takes the text from edit component and displays it', function() {
-      var editComponent = createSpyObjectWith('getText', 'remove');
+      var editComponent = createSpyObjectWith('getText', 'close');
       editComponent.getText.andReturn('edited text');
       componentManager.insertComponent.andReturn(editComponent);
       editableLabel.edit().display();
@@ -47,7 +47,7 @@ describe('EditableLabel', function() {
         constructorArgs: { text: 'edited text' },
         pinTo: pinTo,
       });
-      expect(editComponent.remove).toHaveBeenCalled();
+      expect(editComponent.close).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith('edited text');
     });
   });

--- a/test/Graph-test.js
+++ b/test/Graph-test.js
@@ -40,7 +40,6 @@ describe('Graph', function() {
     state = createSpyObjectWith(
       'persistEdge',
       'persistNode',
-      'persistNodeColor',
       'reset',
       {
         'retrievePersistedEdges.returnValue': [],
@@ -211,14 +210,14 @@ describe('Graph', function() {
       expect(adapter.setNodeColor).toHaveBeenCalledWith(clickTarget, colors.INDIGO);
       expect(adapter.setNodeColor).toHaveBeenCalledWith(clickTarget, colors.VIOLET);
 
-      expect(state.persistNodeColor.calls.length).toBe(7);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.RED);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.ORANGE);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.YELLOW);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.GREEN);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.BLUE);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.INDIGO);
-      expect(state.persistNodeColor).toHaveBeenCalledWith(clickTarget.id, colors.VIOLET);
+      expect(state.persistNode.calls.length).toBe(7);
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.RED });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.ORANGE });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.YELLOW });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.GREEN });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.BLUE });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.INDIGO });
+      expect(state.persistNode).toHaveBeenCalledWith({ id: clickTarget.id, color: colors.VIOLET });
     });
 
     it('tracks colors for nodes separately', function() {

--- a/test/Graph-test.js
+++ b/test/Graph-test.js
@@ -9,6 +9,7 @@ describe('Graph', function() {
   var targetElement;
   var state;
   var editMode;
+  var labelSet;
   var actionQueue;
 
   beforeEach(function() {
@@ -18,6 +19,7 @@ describe('Graph', function() {
       'addNode',
       'getClickTarget',
       'getNodes',
+      'getNode',
       'initialize',
       'setNodeColor',
       'removeNode',
@@ -40,6 +42,7 @@ describe('Graph', function() {
         'retrievePersistedNodes.returnValue': [],
       }
     );
+    labelSet = createSpyObjectWith('initialize');
     targetElement = new MockDomNode();
   });
 
@@ -49,6 +52,7 @@ describe('Graph', function() {
         actionQueue: actionQueue,
         state: state,
         editMode: editMode,
+        labelSet: labelSet,
         holdTime: 100,
       }, options));
   }
@@ -134,6 +138,32 @@ describe('Graph', function() {
         }
       );
       expect(adapter.addNode).toNotHaveBeenCalled();
+    });
+
+    it('initializes the label set with nodes from state', function() {
+      var realNode1 = new graphelements.Node({ id: 0 });
+      var realNode2 = new graphelements.Node({ id: 1 });
+      var realNode3 = new graphelements.Node({ id: 2 });
+      var getNodeIndex = 0;
+
+      graph = newGraph();
+      state.retrievePersistedNodes.andReturn([
+        { id: 0, color: '#0000FF', label: 'asdf', },
+        { id: 1, color: '#00FF00' },
+        { id: 2, label: 'hello' },
+      ]);
+      adapter.getNode.andCall(function() {
+        return [realNode1, realNode2, realNode3][(getNodeIndex++)%3];
+      });
+      state.retrievePersistedEdges.andReturn([]);
+
+      graph.attachTo(targetElement);
+
+      expect(labelSet.initialize).toHaveBeenCalledWith([
+        { node: realNode1, label: 'asdf' },
+        { node: realNode2, label: undefined },
+        { node: realNode3, label: 'hello' },
+      ]);
     });
   });
 

--- a/test/GreulerAdapter-test.js
+++ b/test/GreulerAdapter-test.js
@@ -585,6 +585,45 @@ describe('GreulerAdapter', function() {
     });
   });
 
+  describe('getNode', function() {
+    var adapter;
+    beforeEach(function() {
+      adapter = new GreulerAdapter(greuler);
+      adapter.initialize(new MockDomNode());
+    });
+
+    it('retrieves the node by id', function() {
+      var node = makeNode({ id: 34, index: 0 });
+      graph.getNodesByFn.andReturn([ node ]);
+      instance.nodeGroup = [
+        [
+          {
+            childNodes: [
+              new MockDomNode({
+               'getElementsByTagName.returnValue': [new MockDomNode()],
+              }),
+            ],
+          }
+        ],
+      ];
+
+
+      expect(adapter.getNode(34)).toEqual(
+        new graphelements.Node({
+          id: 34,
+          color: matchers.any(),
+          domElement: matchers.any(),
+          realNode: matchers.any(),
+          getCurrentBoundingBox: matchers.any(Function),
+        })
+      );
+      expect(graph.getNodesByFn).toHaveBeenCalledWith(matchers.functionThatReturns(
+        {input: makeNode({ id: 34 }), output: true },
+        {input: makeNode({ id: 35 }), output: false }
+      ));
+    });
+  });
+
   describe('performInBulk', function() {
     var adapter;
     beforeEach(function() {

--- a/test/GreulerAdapter-test.js
+++ b/test/GreulerAdapter-test.js
@@ -30,17 +30,26 @@ describe('GreulerAdapter', function() {
   });
 
   function makeNode(options) {
-    options = options || {};
+    options = Object.assign({
+      left: 10,
+      top: 30,
+    }, options);
+    if (options.hasOwnProperty('x')) {
+      options.left = options.x;
+    }
+    if (options.hasOwnProperty('y')) {
+      options.top = options.y;
+    }
     return Object.assign({
       id: nodeId++,
       label: '',
       index: 0,
       fill: colors.RED,
       bounds: {
-        x: options.hasOwnProperty('left') ? options.left : 10,
-        X: options.hasOwnProperty('right') ? options.right : 20,
-        y: options.hasOwnProperty('top') ? options.top : 30,
-        Y: options.hasOwnProperty('bottom') ? options.bottom : 40,
+        x: options.left,
+        X: options.right || options.left + 10,
+        y: options.top,
+        Y: options.bottom || options.top + 10,
       },
     }, options);
   };
@@ -364,13 +373,14 @@ describe('GreulerAdapter', function() {
         clientY: 600,
       });
 
-      graph.getNodesByFn.andReturn([
-        { id: 1, index: 0, x: 50, y: 100, width: 10, height: 10, },
-      ]);
+      graph.getNodesByFn.andReturn([]);
 
-      var target = adapter.getClickTarget(event);
-      expect(target).toBeA(graphelements.Node);
-      expect(target.id).toBe(1);
+      adapter.getClickTarget(event);
+
+      expect(graph.getNodesByFn).toHaveBeenCalledWith(matchers.functionThatReturns(
+        { input: makeNode({ x: 50, y: 100 }), output: true },
+        { input: makeNode({ x: 190, y: 600 }), output: false }
+      ));
    });
   });
 

--- a/test/GreulerAdapter-test.js
+++ b/test/GreulerAdapter-test.js
@@ -376,11 +376,11 @@ describe('GreulerAdapter', function() {
 
       var target = adapter.getClickTarget(event);
       expect(target).toBeA(graphelements.Node);
-      expect(target.boundingBox).toEqual(new BoundingBox({
-        left: 110,
-        right: 120,
-        top: 210,
-        bottom: 220,
+      expect(target.getCurrentBoundingBox()).toEqual(new BoundingBox({
+        left: 60,
+        right: 70,
+        top: 110,
+        bottom: 120,
       }));
     });
 
@@ -469,21 +469,21 @@ describe('GreulerAdapter', function() {
           realNode: node1,
           domElement: circle1,
           color: '#FF0000',
-          boundingBox: matchers.any(BoundingBox),
+          getCurrentBoundingBox: matchers.any(Function),
         }),
         new graphelements.Node({
           id: 45,
           realNode: node2,
           domElement: circle2,
           color: '#00FF00',
-          boundingBox: matchers.any(BoundingBox),
+          getCurrentBoundingBox: matchers.any(Function),
         }),
         new graphelements.Node({
           id: 98,
           realNode: node3,
           domElement: circle3,
           color: '#0000FF',
-          boundingBox: matchers.any(BoundingBox),
+          getCurrentBoundingBox: matchers.any(Function),
         }),
       ]);
     });
@@ -512,33 +512,69 @@ describe('GreulerAdapter', function() {
         makeNode({ left: 10, right: 20, top: 40, bottom: 50 }),
         makeNode({ left: 420, right: 450, top: 69, bottom: 71 }),
       ]);
-
-      expect(adapter.getNodes()).toEqual([
-        new graphelements.Node({
-          id: matchers.any(),
-          realNode: matchers.any(),
-          domElement: matchers.any(),
-          color: matchers.any(),
-          boundingBox: new BoundingBox({
+      var results = adapter.getNodes();
+      expect(results.length).toBe(2);
+      expect(results[0].getCurrentBoundingBox).toBeA(Function);
+      expect(results[0].getCurrentBoundingBox()).toEqual(
+        new BoundingBox({
             left: 150,
             right: 160,
             top: 540,
             bottom: 550,
-          }),
-        }),
-        new graphelements.Node({
-          id: matchers.any(),
-          realNode: matchers.any(),
-          domElement: matchers.any(),
-          color: matchers.any(),
-          boundingBox: new BoundingBox({
-            left: 560,
-            right: 570,
-            top: 569,
-            bottom: 571,
-          }),
-        }),
-      ]);
+          })
+      );
+      expect(results[1].getCurrentBoundingBox).toBeA(Function);
+      expect(results[1].getCurrentBoundingBox()).toEqual(
+        new BoundingBox({
+          left: 560,
+          right: 590,
+          top: 569,
+          bottom: 571,
+        })
+      );
+    });
+
+    it('updates the node bounding box automatically', function() {
+      root.getBoundingClientRect.andReturn({
+        left: 140,
+        top: 500,
+      });
+      instance.nodeGroup = [
+        [
+          {
+            childNodes: [
+              new MockDomNode({
+               'getElementsByTagName.returnValue': [new MockDomNode()],
+              }),
+            ],
+          }
+        ],
+      ];
+      var realNode = makeNode({ left: 10, right: 20, top: 40, bottom: 50 });
+      graph.getNodesByFn.andReturn([ realNode ]);
+      var node = adapter.getNodes()[0];
+      expect(node.getCurrentBoundingBox()).toEqual(
+        new BoundingBox({
+            left: 150,
+            right: 160,
+            top: 540,
+            bottom: 550,
+          })
+      );
+      realNode.bounds = {
+        x: 50,
+        X: 60,
+        y: 70,
+        Y: 80,
+      };
+      expect(node.getCurrentBoundingBox()).toEqual(
+        new BoundingBox({
+            left: 190,
+            right: 200,
+            top: 570,
+            bottom: 580,
+          })
+      );
     });
 
     it('passes filter to greuler', function() {

--- a/test/GreulerAdapter-test.js
+++ b/test/GreulerAdapter-test.js
@@ -1,6 +1,7 @@
 var colors = require('../src/colors');
 var GreulerAdapter = require('../src/GreulerAdapter');
 var graphelements = require('../src/graphelements');
+var BoundingBox = require('../src/BoundingBox');
 
 describe('GreulerAdapter', function() {
   var graph;
@@ -363,6 +364,26 @@ describe('GreulerAdapter', function() {
       expect(target.domElement).toBe(domElements[1]);
     });
 
+    it('adds a bounding box to the node', function() {
+      var event = makeEvent({
+        clientX: 50,
+        clientY: 100,
+      });
+
+      graph.getNodesByFn.andReturn([
+        makeNode({ id: 1, index: 0, left: 60, right: 60 + 10, top: 110, bottom: 110 + 10, }),
+      ]);
+
+      var target = adapter.getClickTarget(event);
+      expect(target).toBeA(graphelements.Node);
+      expect(target.boundingBox).toEqual(new BoundingBox({
+        left: 110,
+        right: 120,
+        top: 210,
+        bottom: 220,
+      }));
+    });
+
     it('translates client coordinates into internal coordinates', function() {
       root.getBoundingClientRect.andReturn({
         left: 140,
@@ -448,18 +469,74 @@ describe('GreulerAdapter', function() {
           realNode: node1,
           domElement: circle1,
           color: '#FF0000',
+          boundingBox: matchers.any(BoundingBox),
         }),
         new graphelements.Node({
           id: 45,
           realNode: node2,
           domElement: circle2,
           color: '#00FF00',
+          boundingBox: matchers.any(BoundingBox),
         }),
         new graphelements.Node({
           id: 98,
           realNode: node3,
           domElement: circle3,
           color: '#0000FF',
+          boundingBox: matchers.any(BoundingBox),
+        }),
+      ]);
+    });
+
+    it('adds boundingBox to node', function() {
+      root.getBoundingClientRect.andReturn({
+        left: 140,
+        top: 500,
+      });
+      instance.nodeGroup = [
+        [
+          {
+            childNodes: [
+              new MockDomNode({
+               'getElementsByTagName.returnValue': [new MockDomNode()],
+              }),
+              new MockDomNode({
+               'getElementsByTagName.returnValue': [new MockDomNode()],
+              }),
+            ],
+          }
+        ],
+      ];
+
+      graph.getNodesByFn.andReturn([
+        makeNode({ left: 10, right: 20, top: 40, bottom: 50 }),
+        makeNode({ left: 420, right: 450, top: 69, bottom: 71 }),
+      ]);
+
+      expect(adapter.getNodes()).toEqual([
+        new graphelements.Node({
+          id: matchers.any(),
+          realNode: matchers.any(),
+          domElement: matchers.any(),
+          color: matchers.any(),
+          boundingBox: new BoundingBox({
+            left: 150,
+            right: 160,
+            top: 540,
+            bottom: 550,
+          }),
+        }),
+        new graphelements.Node({
+          id: matchers.any(),
+          realNode: matchers.any(),
+          domElement: matchers.any(),
+          color: matchers.any(),
+          boundingBox: new BoundingBox({
+            left: 560,
+            right: 570,
+            top: 569,
+            bottom: 571,
+          }),
         }),
       ]);
     });

--- a/test/ModeSwitch-test.js
+++ b/test/ModeSwitch-test.js
@@ -123,4 +123,80 @@ describe('ModeSwitch', function() {
       expect(barAction).toHaveBeenCalled();
     });
   });
+
+  describe('if active', function() {
+
+    it('does not perform the action if no mode is active', function() {
+      var action = createSpy();
+      modeSwitch.ifActive({ foo: action });
+      expect(action).toNotHaveBeenCalled();
+    });
+
+    it('does not performs the action if another mode is active', function() {
+      var action = createSpy();
+      modeSwitch
+        .enter('bar')
+        .ifActive({ foo: action });
+      expect(action).toNotHaveBeenCalled();
+    });
+
+    it('performs the action if the mode is active', function() {
+      var action = createSpy();
+      modeSwitch.enter('foo');
+      modeSwitch.ifActive({ foo: action });
+      expect(action).toHaveBeenCalled();
+    });
+
+    it('ignores the other actions', function() {
+      var fooAction = createSpy();
+      var barAction = createSpy();
+      modeSwitch.enter('foo');
+      modeSwitch.ifActive({
+        foo: fooAction,
+        bar: barAction,
+      });
+      expect(fooAction).toHaveBeenCalled();
+      expect(barAction).toNotHaveBeenCalled();
+    });
+
+    it('passes mode state to the action', function() {
+      var action = createSpy();
+      modeSwitch
+        .enter('foo', function() { return { a: 'b' }; })
+        .ifActive({ foo: action });
+
+      expect(action).toHaveBeenCalledWith({ a: 'b' });
+    });
+
+    it('does not set action return value as state', function() {
+      var action = createSpy();
+      modeSwitch
+        .enter('foo', function() { return { original: 'state' }; })
+        .ifActive({ foo: function() { return { a: 'b' }; } })
+        .exit('foo', action);
+
+      expect(action).toHaveBeenCalledWith({ original: 'state' });
+    });
+
+    it('does not enter the mode', function() {
+      var barAction = createSpy();
+      modeSwitch
+        .ifActive({ foo: function() {} })
+        .enter('bar', barAction);
+      expect(barAction).toHaveBeenCalled();
+    });
+
+    it('does not exit the mode', function() {
+      var barAction = createSpy();
+      modeSwitch
+        .enter('foo')
+        .ifActive({ foo: function() {} })
+        .enter('bar', barAction);
+      expect(barAction).toNotHaveBeenCalled();
+
+      actionQueue.step(10);
+      modeSwitch.enter('bar', barAction);
+      expect(barAction).toNotHaveBeenCalled();
+    });
+  });
 });

--- a/test/ModeSwitch-test.js
+++ b/test/ModeSwitch-test.js
@@ -103,5 +103,15 @@ describe('ModeSwitch', function() {
 
       expect(barAction).toNotHaveBeenCalled();
     });
+
+    it('immediately resets mode if no timeout is specified', function() {
+      modeSwitch = new ModeSwitch();
+      var barAction = createSpy();
+      modeSwitch.enter('foo');
+      modeSwitch.exit('foo');
+
+      modeSwitch.enter('bar', barAction);
+      expect(barAction).toHaveBeenCalled();
+    });
   });
 });

--- a/test/ModeSwitch-test.js
+++ b/test/ModeSwitch-test.js
@@ -47,6 +47,15 @@ describe('ModeSwitch', function() {
       modeSwitch.enter('bar', barAction);
       expect(barAction).toNotHaveBeenCalled();
     });
+
+    it('stores the return value of enter function to pass to exit function', function() {
+      var modeState = { hello: 'world' };
+      var enterAction = createSpy().andReturn(modeState);
+      var exitAction = createSpy();
+      modeSwitch.enter('foo', enterAction);
+      modeSwitch.exit('foo', exitAction);
+      expect(exitAction).toHaveBeenCalledWith(modeState);
+    });
   });
 
   describe('mode.exit', function() {

--- a/test/NodeLabelSet-test.js
+++ b/test/NodeLabelSet-test.js
@@ -107,7 +107,7 @@ describe('NodeLabelSet', function() {
       expect(label.display).toNotHaveBeenCalled();
     });
 
-    it('reuses an existing label', function() {
+    it('reuses an existing label from initial data', function() {
       var node = createNode({ id: 123 });
       labelSet.initialize([
         { node: node, label: 'hello' }
@@ -121,6 +121,22 @@ describe('NodeLabelSet', function() {
       expect(label.edit).toHaveBeenCalled();
       expect(label.display).toNotHaveBeenCalled();
     });
+
+    it('reuses an existing label from a previous mode', function() {
+      var node = createNode({ id: 123 });
+
+      labelSet.display(node);
+
+      labelFactory.create.reset();
+      label.reset();
+
+      labelSet.edit(node);
+
+      expect(labelFactory.create).toNotHaveBeenCalled();
+      expect(label.edit).toHaveBeenCalled();
+      expect(label.display).toNotHaveBeenCalled();
+    });
+
   });
 
   describe('display', function() {
@@ -132,11 +148,26 @@ describe('NodeLabelSet', function() {
       expect(label.edit).toNotHaveBeenCalled();
     });
 
-    it('reuses an existing label', function() {
+    it('reuses an existing label from initial data', function() {
       var node = createNode({ id: 123 });
       labelSet.initialize([
         { node: node, label: 'hello' }
       ]);
+      labelFactory.create.reset();
+      label.reset();
+
+      labelSet.display(node);
+
+      expect(labelFactory.create).toNotHaveBeenCalled();
+      expect(label.edit).toNotHaveBeenCalled();
+      expect(label.display).toHaveBeenCalled();
+    });
+
+    it('reuses an existing label from a previous mode', function() {
+      var node = createNode({ id: 123 });
+
+      labelSet.edit(node);
+
       labelFactory.create.reset();
       label.reset();
 

--- a/test/NodeLabelSet-test.js
+++ b/test/NodeLabelSet-test.js
@@ -1,0 +1,150 @@
+var NodeLabelSet = require('../src/NodeLabelSet');
+var Position = require('../src/Position');
+var BoundingBox = require('../src/BoundingBox');
+
+describe('NodeLabelSet', function() {
+  var componentManager;
+  var state;
+  var nodeLabelSet;
+  var labelFactory;
+  var label;
+  var labelSet;
+
+  beforeEach(function() {
+    componentManager = createSpyObjectWith('insertComponent');
+    state = createSpyObjectWith('persistNode');
+    label = createSpyObjectWith({
+      'display.returnValue': 'this',
+      'edit.returnValue': 'this',
+    });
+    labelFactory = createSpyObjectWith({
+      'create.returnValue': label,
+    });
+    labelSet = new NodeLabelSet({
+      componentManager: componentManager,
+      state: state,
+      editableLabelFactory: labelFactory,
+    });
+  });
+
+  function createNode(opts) {
+    return Object.assign(
+      createSpyObjectWith({
+        'getCurrentBoundingBox.returnValue': new BoundingBox(),
+      }),
+      opts
+    );
+  }
+
+  function expectLabelToHaveBeenCreated(node, label) {
+    var reset = function() { node.getCurrentBoundingBox.reset() };
+    expect(labelFactory.create).toHaveBeenCalledWith({
+      text: label,
+      componentManager: componentManager,
+      pinTo: matchers.functionThatHasSideEffect({
+        before: function() { expect(node.getCurrentBoundingBox).toNotHaveBeenCalled(); },
+        after: function(result) {
+          expect(node.getCurrentBoundingBox).toHaveBeenCalled();
+          expect(result).toEqual(new Position({
+            bottomRight: node.getCurrentBoundingBox().getTopLeft()
+          }));
+
+        },
+        reset: function() {
+          node.getCurrentBoundingBox.reset();
+        },
+      }),
+      onChange: matchers.functionThatHasSideEffect({
+        arguments: ['askjf'],
+        before: function() { expect(state.persistNode).toNotHaveBeenCalled(); },
+        after: function() {
+          expect(state.persistNode).toHaveBeenCalledWith({
+            id: node.id,
+            label: 'askjf',
+          });
+        },
+        reset: function() { state.persistNode.reset(); },
+      }),
+    });
+  }
+
+  describe('initialize', function() {
+    it('creates labels for each of the nodes that has a label', function() {
+      var label1 = createSpyObjectWith('display', 'edit');
+      var label2 = createSpyObjectWith('display', 'edit');
+      labelFactory.create.andCall(function(opts) {
+        return opts.text === 'hello' ? label1 : label2;
+      });
+
+
+      var node1 = createNode({ id: 1 });
+      var node2 = createNode({ id: 2 });
+      var node3 = createNode({ id: 3 });
+      labelSet.initialize([
+        { node: node1, label: 'hello' },
+        { node: node2, label: '' },
+        { node: node3, label: 'world' },
+      ]);
+
+      expectLabelToHaveBeenCreated(node1, 'hello');
+      expectLabelToHaveBeenCreated(node3, 'world');
+      expect(labelFactory.create.calls.length).toBe(2);
+
+      expect(label1.display).toHaveBeenCalled();
+      expect(label1.edit).toNotHaveBeenCalled();
+
+      expect(label2.display).toHaveBeenCalled();
+      expect(label2.edit).toNotHaveBeenCalled();
+    });
+  });
+
+  describe('edit', function() {
+    it('creates a label for the node if it does not already have one', function() {
+      var node = createNode({ id: 123 });
+      labelSet.edit(node);
+      expectLabelToHaveBeenCreated(node);
+      expect(label.edit).toHaveBeenCalled();
+      expect(label.display).toNotHaveBeenCalled();
+    });
+
+    it('reuses an existing label', function() {
+      var node = createNode({ id: 123 });
+      labelSet.initialize([
+        { node: node, label: 'hello' }
+      ]);
+      labelFactory.create.reset();
+      label.reset();
+
+      labelSet.edit(node);
+
+      expect(labelFactory.create).toNotHaveBeenCalled();
+      expect(label.edit).toHaveBeenCalled();
+      expect(label.display).toNotHaveBeenCalled();
+    });
+  });
+
+  describe('display', function() {
+    it('creates a label for the node if it does not already have one', function() {
+      var node = createNode({ id: 123 });
+      labelSet.display(node);
+      expectLabelToHaveBeenCreated(node);
+      expect(label.display).toHaveBeenCalled();
+      expect(label.edit).toNotHaveBeenCalled();
+    });
+
+    it('reuses an existing label', function() {
+      var node = createNode({ id: 123 });
+      labelSet.initialize([
+        { node: node, label: 'hello' }
+      ]);
+      labelFactory.create.reset();
+      label.reset();
+
+      labelSet.display(node);
+
+      expect(labelFactory.create).toNotHaveBeenCalled();
+      expect(label.edit).toNotHaveBeenCalled();
+      expect(label.display).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/Position-test.js
+++ b/test/Position-test.js
@@ -4,22 +4,22 @@ describe('Position', function() {
   describe('getStyle', function() {
     it('returns correct style for top left position', function() {
       var position = new Position({ topLeft: { x: 12, y: 789 } });
-      expect(position.getStyle()).toEqual('position: absolute; left: 12; top: 789;');
+      expect(position.getStyle({ width: 10, height: 100 })).toEqual('position: absolute; left: 12; top: 789;');
     });
 
     it('returns correct style for bottom left position', function() {
       var position = new Position({ bottomLeft: { x: 12, y: 789 } });
-      expect(position.getStyle()).toEqual('position: absolute; left: 12; bottom: 789;');
+      expect(position.getStyle({ width: 10, height: 100 })).toEqual('position: absolute; left: 12; top: 689;');
     });
 
     it('returns correct style for top right position', function() {
       var position = new Position({ topRight: { x: 12, y: 789 } });
-      expect(position.getStyle()).toEqual('position: absolute; right: 12; top: 789;');
+      expect(position.getStyle({ width: 10, height: 100 })).toEqual('position: absolute; left: 2; top: 789;');
     });
 
     it('returns correct style for bottom right position', function() {
       var position = new Position({ bottomRight: { x: 12, y: 789 } });
-      expect(position.getStyle()).toEqual('position: absolute; right: 12; bottom: 789;');
+      expect(position.getStyle({ width: 10, height: 100 })).toEqual('position: absolute; left: 2; top: 689;');
     });
   });
 });

--- a/test/Position-test.js
+++ b/test/Position-test.js
@@ -1,0 +1,25 @@
+var Position = require('../src/Position');
+
+describe('Position', function() {
+  describe('getStyle', function() {
+    it('returns correct style for top left position', function() {
+      var position = new Position({ topLeft: { x: 12, y: 789 } });
+      expect(position.getStyle()).toEqual('position: absolute; left: 12; top: 789;');
+    });
+
+    it('returns correct style for bottom left position', function() {
+      var position = new Position({ bottomLeft: { x: 12, y: 789 } });
+      expect(position.getStyle()).toEqual('position: absolute; left: 12; bottom: 789;');
+    });
+
+    it('returns correct style for top right position', function() {
+      var position = new Position({ topRight: { x: 12, y: 789 } });
+      expect(position.getStyle()).toEqual('position: absolute; right: 12; top: 789;');
+    });
+
+    it('returns correct style for bottom right position', function() {
+      var position = new Position({ bottomRight: { x: 12, y: 789 } });
+      expect(position.getStyle()).toEqual('position: absolute; right: 12; bottom: 789;');
+    });
+  });
+});

--- a/test/TextBox-test.js
+++ b/test/TextBox-test.js
@@ -1,0 +1,45 @@
+var TextBox = require('../src/TextBox');
+var MockActionQueue = require('./utils/MockActionQueue');
+var MockDomNode = require('./utils/MockDomNode');
+
+describe('TextBox', function() {
+
+  describe('getGeneratedMarkup', function() {
+
+    it('returns an input with initial text', function() {
+      var component = new TextBox({ text: 'hello' });
+      expect(component.getGeneratedMarkup()).toEqual(
+        '<input type="text" value="hello"></input>'
+      );
+    });
+
+    it('returns an input with no initial text', function() {
+      var component = new TextBox();
+      expect(component.getGeneratedMarkup()).toEqual(
+        '<input type="text" value=""></input>'
+      );
+    });
+  });
+
+  describe('getText', function() {
+    var component;
+    var mainElement;
+    var inputElement;
+    beforeEach(function() {
+      component = new TextBox({
+        actionQueue: new MockActionQueue(),
+      });
+      inputElement = new MockDomNode();
+      mainElement = new MockDomNode({
+        'getElementsByTagName.returnValue': [inputElement],
+      });
+      component.attachTo(mainElement);
+    });
+
+    it('returns the value of the input element', function() {
+      inputElement.value = 'foobar';
+      expect(component.getText()).toEqual('foobar');
+      expect(mainElement.getElementsByTagName).toHaveBeenCalledWith('input');
+    });
+  });
+});

--- a/test/UrlState-test.js
+++ b/test/UrlState-test.js
@@ -43,6 +43,40 @@ describe('UrlState', function() {
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_FFFFFF', matchers.hexEncodedBinary('10000000'));
     });
 
+    it('persists a new node\'s label if it is provided', function() {
+      urlSearchParams.setNumericParam('n', 7);
+      state.persistNode({ label: 'hello' });
+      expect(urlSearchParams.set).toHaveBeenCalledWith('l_7', 'hello');
+    });
+
+    it('encodes a new node\'s label before setting on the params', function() {
+      urlSearchParams.setNumericParam('n', 2);
+      state.persistNode({ label: 'hello world:' });
+      expect(urlSearchParams.set).toHaveBeenCalledWith('l_2', 'hello%20world%3A');
+    });
+
+    it('updates a node label', function() {
+      urlSearchParams.setNumericParam('n', 3);
+      state.persistNode({ id: 1, label: 'hello world:' });
+      expect(urlSearchParams.set).toHaveBeenCalledWith('l_1', 'hello%20world%3A');
+    });
+
+    it('does not change a node\'s color if only a label is provided', function() {
+      urlSearchParams.setNumericParam('n', 5);
+      urlSearchParams.setHexEncodedBinary('c_FFFFFF', '1010');
+      state.persistNode({ id: 1, label: 'hello' });
+      expect(urlSearchParams.get('c_FFFFFF')).toEqual(matchers.hexEncodedBinary('1010'));
+    });
+
+    it('does not change a node\'s label if only a color is provided', function() {
+      urlSearchParams.setNumericParam('n', 5);
+      urlSearchParams.set('l_1', 'hello');
+      urlSearchParams.setHexEncodedBinary('c_FFFFFF', '1000');
+      state.persistNode({ id: 1, color: '#FFFFFF' });
+      expect(urlSearchParams.get('l_1')).toEqual('hello');
+      expect(urlSearchParams.set).toHaveBeenCalledWith('c_FFFFFF', matchers.hexEncodedBinary('1010'));
+    });
+
     it('persists a new node\'s color to existing color bitmask', function() {
       urlSearchParams.setNumericParam('n', 5);
       urlSearchParams.setHexEncodedBinary('c_FFFFFF', '1010');
@@ -110,6 +144,17 @@ describe('UrlState', function() {
         { id: 3, color: '#FF0000' },
         { id: 4, color: '#FF0000' },
         { id: 5, color: '#0000FF' },
+      ]);
+    });
+
+    it('returns node labels if present', function() {
+      urlSearchParams.setNumericParam('n', 3);
+      urlSearchParams.set('l_0', 'hello');
+      urlSearchParams.set('l_2', encodeURIComponent('what\'s up doc'));
+      expect(state.retrievePersistedNodes()).toEqual([
+        { id: 0, label: 'hello' },
+        { id: 1 },
+        { id: 2, label: 'what\'s up doc' },
       ]);
     });
   });

--- a/test/UrlState-test.js
+++ b/test/UrlState-test.js
@@ -24,56 +24,42 @@ describe('UrlState', function() {
     afterEach(expectStateToHaveBeenPushed);
 
     it('sets the number of nodes to 1 if there are no nodes', function() {
-      spyOn(state, 'persistNodeColor');
       urlSearchParams.has.andReturn(false);
       var id = state.persistNode();
       expect(id).toBe(0);
       expect(urlSearchParams.set).toHaveBeenCalledWith('n', 1);
-      expect(state.persistNodeColor).toNotHaveBeenCalled();
     });
 
     it('increments number of nodes', function() {
-      spyOn(state, 'persistNodeColor');
       urlSearchParams.setNumericParam('n', 4);
       var id = state.persistNode();
       expect(id).toBe(4);
       expect(urlSearchParams.set).toHaveBeenCalledWith('n', 5);
-      expect(state.persistNodeColor).toNotHaveBeenCalled();
     });
 
-    it('persists the node color if it is provided', function() {
-      spyOn(state, 'persistNodeColor');
+    it('persists a new node\'s color if it is provided', function() {
       urlSearchParams.setNumericParam('n', 7);
       state.persistNode({ color: '#FFFFFF' });
-      expect(state.persistNodeColor).toHaveBeenCalled();
-    });
-  });
-
-  describe('persistNodeColor', function() {
-
-    afterEach(expectStateToHaveBeenPushed);
-
-    it('adds a param with node color', function() {
-      state.persistNodeColor(7, '#FFFFFF' );
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_FFFFFF', matchers.hexEncodedBinary('10000000'));
     });
 
-    it('persists the node color to existing color bitmask', function() {
+    it('persists a new node\'s color to existing color bitmask', function() {
+      urlSearchParams.setNumericParam('n', 5);
       urlSearchParams.setHexEncodedBinary('c_FFFFFF', '1010');
-      state.persistNodeColor(5, '#FFFFFF' );
+      state.persistNode({ color: '#FFFFFF' });
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_FFFFFF', matchers.hexEncodedBinary('101010'));
     });
 
-    it('removes the existing color from the node', function() {
+    it('removes existing color from the node if changing colors', function() {
       urlSearchParams.setHexEncodedBinary('c_FFFFFF', '1010');
-      state.persistNodeColor(3, '#00FF00' );
+      state.persistNode({ id: 3, color: '#00FF00' });
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_FFFFFF', matchers.hexEncodedBinary('0010'));
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_00FF00', matchers.hexEncodedBinary('1000'));
     });
 
     it('removes the existing color param if node was only one with color', function() {
       urlSearchParams.setHexEncodedBinary('c_FFFFFF', '10');
-      state.persistNodeColor(1, '#00FF00' );
+      state.persistNode({ id: 1, color: '#00FF00' });
       expect(urlSearchParams.delete).toHaveBeenCalledWith('c_FFFFFF');
       expect(urlSearchParams.set).toHaveBeenCalledWith('c_00FF00', matchers.hexEncodedBinary('10'));
     });

--- a/test/UrlState-test.js
+++ b/test/UrlState-test.js
@@ -115,6 +115,22 @@ describe('UrlState', function() {
     });
   });
 
+  describe('retrieve node', function() {
+    it('returns just the node id if there is no other data', function() {
+      expect(state.retrieveNode(3)).toEqual({ id: 3 });
+    });
+
+    it('returns the node\'s color and label', function() {
+      urlSearchParams.setHexEncodedBinary('c_0000FF', '101001');
+      urlSearchParams.set('l_3', 'hello%20world');
+      expect(state.retrieveNode(3)).toEqual({
+        id: 3,
+        color: '#0000FF',
+        label: 'hello world',
+      });
+    });
+  });
+
   describe('retrieve persisted nodes', function() {
     it('returns empty array if there is no node param', function() {
       expect(state.retrievePersistedNodes()).toEqual([]);

--- a/test/graphelements-test.js
+++ b/test/graphelements-test.js
@@ -1,0 +1,23 @@
+var graphelements = require('../src/graphelements');
+var BoundingBox = require('../src/BoundingBox');
+
+describe('Node', function() {
+  it('can return its position from the supplied bounding box', function() {
+    var boundingBox = new BoundingBox({
+      left: 10,
+      right: 20,
+      top: 30,
+      bottom: 40,
+    });
+    var node = new graphelements.Node({
+      realNode: createSpyObjectWith(),
+      color: '#FFFFFF',
+      getCurrentBoundingBox: function() { return boundingBox; },
+    });
+    expect(node.getCenter()).toEqual({ x: 15, y: 35 });
+    expect(node.getTopLeft()).toEqual({ x: 10, y: 30 });
+    expect(node.getTopRight()).toEqual({ x: 20, y: 30 });
+    expect(node.getBottomLeft()).toEqual({ x: 10, y: 40 });
+    expect(node.getBottomRight()).toEqual({ x: 20, y: 40 });
+  });
+});

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -77,4 +77,27 @@ describe('utils', function() {
       expect(normalized.clientY).toBe(56);
     });
   });
+
+  describe('isOneValuedObject', function() {
+    it('returns false if the object is not present', function() {
+      expect(utils.isOneValuedObject()).toBe(false)
+      expect(utils.isOneValuedObject(undefined)).toBe(false)
+      expect(utils.isOneValuedObject(null)).toBe(false)
+    });
+
+    it('returns false if the value is not an object', function() {
+      expect(utils.isOneValuedObject([])).toBe(false)
+      expect(utils.isOneValuedObject(['hello'])).toBe(false)
+      expect(utils.isOneValuedObject('h')).toBe(false)
+    });
+
+    it('returns true if the object has one value', function() {
+      expect(utils.isOneValuedObject({})).toBe(false)
+      expect(utils.isOneValuedObject({a: 'b'})).toBe(true)
+      expect(utils.isOneValuedObject({a: 'b', c: undefined})).toBe(true)
+      expect(utils.isOneValuedObject({a: 'b', c: null})).toBe(true)
+      expect(utils.isOneValuedObject({a: 'b', c: 'd'})).toBe(false)
+    });
+
+  });
 });

--- a/test/utils/MockActionQueue.js
+++ b/test/utils/MockActionQueue.js
@@ -1,6 +1,7 @@
 function MockActionQueue() {
   this.currentTime = 0;
   this.pendingCalls = {};
+  this.mainQueueInterval = 420;
   spyOn(this, 'defer').andCallThrough();
 }
 
@@ -37,6 +38,21 @@ MockActionQueue.prototype = {
           this.pendingCalls[callTime].splice(this.pendingCalls[callTime].indexOf(callback), 1);
         }
       }).bind(this),
+    };
+  },
+
+  periodically: function(fn) {
+    var cancelable;
+    var queuedFn = (function() {
+      fn();
+      cancelable = this.defer(this.mainQueueInterval, queuedFn);
+    }).bind(this)
+
+    cancelable = this.defer(this.mainQueueInterval, queuedFn);
+    return {
+      cancel: function() {
+        cancelable.cancel();
+      },
     };
   },
 };

--- a/test/utils/MockDomNode.js
+++ b/test/utils/MockDomNode.js
@@ -3,6 +3,7 @@ var createSpy = require('expect').createSpy;
 function MockDomNode(options) {
   options = Object.assign({
     'getElementsByTagName.returnValue': [],
+    'remove.returnValue': undefined,
   }, options);
 
   this.attributes = {};

--- a/test/utils/MockDomNode.js
+++ b/test/utils/MockDomNode.js
@@ -1,7 +1,9 @@
 var createSpy = require('expect').createSpy;
 
 function MockDomNode(options) {
-  options = options || {};
+  options = Object.assign({
+    'getElementsByTagName.returnValue': [],
+  }, options);
 
   this.attributes = {};
 

--- a/test/utils/expectations.js
+++ b/test/utils/expectations.js
@@ -17,6 +17,22 @@ expect.extend({
     this.toBeA.apply(this, arguments);
   },
 
+  toEqual: function(expected) {
+    var matcher = matchers.equals(expected).match(this.actual);
+    try {
+      expect.assert(
+        matcher.matches,
+        'expected %s to equal %s',
+        this.actual,
+        expected
+      );
+    } catch(error) {
+      error.expected = expected;
+      error.actual = this.actual;
+      throw error;
+    }
+  },
+
   toHaveBeenCalledWith: function() {
     this.toHaveBeenCalled();
     var expected = Array.prototype.map.call(arguments, function(e) {

--- a/test/utils/matchers.js
+++ b/test/utils/matchers.js
@@ -3,7 +3,7 @@ var isEqual = require('is-equal');
 function isEqualRespectingMatchers(expected, actual) {
   if (expected && expected._isMatcher) {
     return expected.match(actual).matches;
-  } else if (typeof expected === 'object') {
+  } else if (typeof expected === 'object' && expected !== null) {
     return Object.keys(expected).every(function(key) {
       return isEqualRespectingMatchers(expected[key], actual[key]);
     });

--- a/test/utils/matchers.js
+++ b/test/utils/matchers.js
@@ -86,6 +86,41 @@ module.exports = {
     };
   },
 
+  functionThatHasSideEffect: function(opts) {
+    opts = Object.assign({
+      arguments: undefined,
+      before: function() {},
+      after: function() {},
+      reset: function() {},
+    }, opts);
+    return {
+      match: function(fn) {
+        if (typeof fn === 'function') {
+          try {
+            opts.before();
+            var result = fn.apply(
+              null,
+              Array.isArray(opts.arguments) ? opts.arguments : [opts.arguments]
+            );
+            opts.after(result);
+            return {
+              matches: true,
+            };
+          } finally {
+            opts.reset();
+          }
+        } else {
+          return {
+            matches: false,
+            expected: 'function',
+            actual: fn,
+          };
+        }
+      },
+      _isMatcher: true,
+    };
+  },
+
   hexEncodedBinary: function(binaryString) {
     var expectedHex = parseInt(binaryString, 2).toString(16);
     return {

--- a/test/utils/spy-obj.js
+++ b/test/utils/spy-obj.js
@@ -3,6 +3,11 @@ var createSpy = require('expect').createSpy;
 createSpyObjectWith = function() {
   var obj = {};
   var spies = [];
+  function setSpy(name, spy) {
+    obj[name] = spy;
+    spies.push(spy);
+  }
+
   Array.prototype.forEach.call(arguments, function(fnName) {
     if (typeof fnName === 'object') {
       var spy = null;;
@@ -10,18 +15,13 @@ createSpyObjectWith = function() {
       Object.keys(spec).forEach(function(key) {
         var value = spec[key];
         if (key.endsWith('.returnValue')) {
-          spy = createSpy().andReturn(value === 'this' ? obj : value);
-          obj[key.split('.')[0]] = spy;
+          setSpy(key.split('.')[0], createSpy().andReturn(value === 'this' ? obj : value));
         } else {
           obj[key] = value;
         }
       });
     } else {
-      spy = createSpy();
-      obj[fnName] = spy;
-    }
-    if (spy) {
-      spies.push(spy);
+      setSpy(fnName, createSpy());
     }
   });
   obj.reset = obj.reset || function() {

--- a/test/utils/spy-obj.js
+++ b/test/utils/spy-obj.js
@@ -2,21 +2,31 @@ var createSpy = require('expect').createSpy;
 
 createSpyObjectWith = function() {
   var obj = {};
+  var spies = [];
   Array.prototype.forEach.call(arguments, function(fnName) {
     if (typeof fnName === 'object') {
+      var spy = null;;
       var spec = fnName;
       Object.keys(spec).forEach(function(key) {
         var value = spec[key];
         if (key.endsWith('.returnValue')) {
-          obj[key.split('.')[0]] = createSpy().andReturn(value === 'this' ? obj : value);
+          spy = createSpy().andReturn(value === 'this' ? obj : value);
+          obj[key.split('.')[0]] = spy;
         } else {
           obj[key] = value;
         }
       });
     } else {
-      obj[fnName] = createSpy();
+      spy = createSpy();
+      obj[fnName] = spy;
+    }
+    if (spy) {
+      spies.push(spy);
     }
   });
+  obj.reset = obj.reset || function() {
+    spies.forEach(function(s) { s.reset() });
+  }
   return obj;
 };
 


### PR DESCRIPTION
This adds the ability to add labels to nodes. The main technical challenge was that the labels provided by Greuler (the library I'm using to manage the graph) are only long enough to fit a single character. So I had to add my own labels that tracked the nodes.

This PR is more heavy-weight than was strictly necessarily to solve the problem, but I wanted to take the opportunity to introduce some concepts and tools into the codebase that I forsee being useful and that cover up existing pain points.

1. `ComponentManager` to insert components into the dom. I'm going to need this to flesh out the UI more - I may need to insert a slider to change the node's size, a delete button for nodes and edges, etc.
2. Extracting `EditMode` from the `Graph` class. `Graph` was maintaining a bunch of state distinctly related to edit mode, which is one sign that it should have been abstracted. But I also want to be able to create graphs with different allowed edits - e.g. a graph illustrating the four color theorem in which you cannot add nodes or edges but can change colors. I can get that kind of configurability by injecting different versions of EditMode. I need some joints in `Graph` with which to alter its behavior.
3. EditMode entailed a lot of refactoring around state management. I noticed this pattern of switching between two modes come up a lot in the codebase, so I started using `ModeSwitch`. Then I noticed that modes wanted to have some data about them - the last mouse down event in the event mode switch, the node being edited, the display vs input component for the label, etc.
