### PR TITLE
EditableLabel - handle entering the same mode twice in a row

### DIFF
--- a/src/EditableLabel.js
+++ b/src/EditableLabel.js
@@ -24,7 +24,8 @@ EditableLabel.prototype = {
       this.text = editState.component.getText();
       editState.component.close();
       LOG.debug('EditableLabel: got text from input component', this.text);
-    }).bind(this));
+    }).bind(this))
+    .exit('display', function(displayState) { displayState.component.close(); });
 
     if (this.text) {
       this.modeSwitch.enter('display', (function() {
@@ -47,7 +48,8 @@ EditableLabel.prototype = {
     this.modeSwitch.exit('display', (function(displayState) {
       displayState.component.close();
       LOG.debug('EditableLabel: closed display component');
-    }).bind(this));
+    }).bind(this))
+    .exit('edit', function(editState) { editState.component.close(); });
 
     this.modeSwitch.enter('edit', (function() {
        var component = this.componentManager.insertComponent({
@@ -77,7 +79,11 @@ EditableLabel.prototype = {
     this.modeSwitch
       .exit('display', function(displayState) { displayState.component.close(); })
       .exit('edit', function(editState) { editState.component.close(); }) ;
+    return this;
+  },
 
+  _closeComponent: function(state) {
+    state.component.close();
   },
 };
 

--- a/test/EditableLabel-test.js
+++ b/test/EditableLabel-test.js
@@ -50,6 +50,22 @@ describe('EditableLabel', function() {
       expect(editComponent.close).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith('edited text');
     });
+
+    it('can be called twice in a row', function() {
+      var displayComponent1 = createSpyObjectWith('close');
+      var displayComponent2 = createSpyObjectWith('close');
+      var insertCallCount = 0;
+      componentManager.insertComponent.andCall(function() {
+        return [displayComponent1, displayComponent2][(insertCallCount++)%2];
+      });
+
+      editableLabel.text = 'hello';
+      editableLabel.display();
+      editableLabel.display();
+
+      expect(displayComponent1.close).toHaveBeenCalled();
+      expect(displayComponent2.close).toNotHaveBeenCalled();
+    });
   });
 
   describe('edit', function() {
@@ -96,6 +112,22 @@ describe('EditableLabel', function() {
         pinTo: pinTo,
       });
     });
+
+    it('can be called twice in a row', function() {
+      var editComponent1 = createSpyObjectWith('close');
+      var editComponent2 = createSpyObjectWith('close');
+      var insertCallCount = 0;
+      componentManager.insertComponent.andCall(function() {
+        return [editComponent1, editComponent2][(insertCallCount++)%2];
+      });
+
+      editableLabel.edit();
+      editableLabel.edit();
+
+      expect(editComponent1.close).toHaveBeenCalled();
+      expect(editComponent2.close).toNotHaveBeenCalled();
+    });
+
   });
 
   describe('close', function() {


### PR DESCRIPTION
Now that the EditableLabels enter `display` mode when enter is pressed,
they can go into display mode twice in a row: once when enter is pressed
and then again when edit mode is exited. That left a stranded display
component.