### PR TITLE
utils.requireNonNull - include property name in error

### DIFF
--- a/src/graphs/ColorChanger.js
+++ b/src/graphs/ColorChanger.js
@@ -9,10 +9,10 @@ ColorChanger.prototype = {
   getConstructorArgs: function() { return {}; },
 
   setColor: function(opts) {
-    var adapter = utils.requireNonNull(opts.adapter);
-    var state = utils.requireNonNull(opts.state);
-    var node = utils.requireNonNull(opts.node);
-    var color = utils.requireNonNull(opts.color);
+    var adapter = utils.requireNonNull(opts, 'adapter');
+    var state = utils.requireNonNull(opts, 'state');
+    var node = utils.requireNonNull(opts, 'node');
+    var color = utils.requireNonNull(opts, 'color');
 
     adapter.setNodeColor(node, color);
     state.persistNode({ id: node.id, color: color });

--- a/src/graphs/EdgeCreator.js
+++ b/src/graphs/EdgeCreator.js
@@ -9,10 +9,10 @@ EdgeCreator.prototype = {
   getConstructorArgs: function() { return {}; },
 
   addEdge: function(opts) {
-    var adapter = utils.requireNonNull(opts.adapter);
-    var state = utils.requireNonNull(opts.state);
-    var source = utils.requireNonNull(opts.source);
-    var target = utils.requireNonNull(opts.target);
+    var adapter = utils.requireNonNull(opts, 'adapter');
+    var state = utils.requireNonNull(opts, 'state');
+    var source = utils.requireNonNull(opts, 'source');
+    var target = utils.requireNonNull(opts, 'target');
     var edgeDistance = opts.edgeDistance;
 
     adapter.addEdge({

--- a/src/graphs/NodeCreator.js
+++ b/src/graphs/NodeCreator.js
@@ -8,9 +8,9 @@ NodeCreator.prototype = {
   getConstructorArgs: function() { return {}; },
 
   addNode: function(opts) {
-    var state = utils.requireNonNull(opts.state);
-    var adapter = utils.requireNonNull(opts.adapter);
-    var color = utils.requireNonNull(opts.color);
+    var state = utils.requireNonNull(opts, 'state');
+    var adapter = utils.requireNonNull(opts, 'adapter');
+    var color = utils.requireNonNull(opts, 'color');
     var nodeSize = opts.nodeSize;
 
     var nodeId = state.persistNode({

--- a/src/graphs/graphfactory.js
+++ b/src/graphs/graphfactory.js
@@ -37,8 +37,8 @@ module.exports = {
 
 
     return new Graph({
-      actionQueue: utils.requireNonNull(opts.actionQueue),
-      adapter: utils.requireNonNull(opts.adapter),
+      actionQueue: utils.requireNonNull(opts, 'actionQueue'),
+      adapter: utils.requireNonNull(opts, 'adapter'),
       colorChoices: opts.colorChoices,
       colorChanger: this._getColorChanger(opts),
       edgeCreator: this._getEdgeCreator(opts),
@@ -48,7 +48,7 @@ module.exports = {
       labelSet: this._getLabelSet(opts),
       nodeCreator: this._getNodeCreator(opts),
       nodeSize: opts.nodeSize,
-      state: utils.requireNonNull(opts.state),
+      state: utils.requireNonNull(opts, 'state'),
     });
   },
 
@@ -67,7 +67,7 @@ module.exports = {
 
     return new GraphComponent(Object.assign({
       graph: this.newGraph(Object.assign({ labelSet: labelSet }, opts)),
-      adapter: utils.requireNonNull(opts.adapter),
+      adapter: utils.requireNonNull(opts, 'adapter'),
       editMode: this._getEditMode(opts, labelSet),
       width: opts.width,
       height: opts.height,
@@ -77,14 +77,14 @@ module.exports = {
 
   _newComponentManager: function(opts) {
     return new ComponentManager({
-      actionQueue: utils.requireNonNull(opts.actionQueue),
+      actionQueue: utils.requireNonNull(opts, 'actionQueue'),
       componentServices: this._getComponentServices(opts),
-      document: utils.requireNonNull(opts.document),
+      document: utils.requireNonNull(opts, 'document'),
     });
   },
 
   _getComponentServices: function(opts) {
-    var actionQueue = utils.requireNonNull(opts.actionQueue);
+    var actionQueue = utils.requireNonNull(opts, 'actionQueue');
     return { actionQueue: actionQueue };
   },
 
@@ -117,14 +117,14 @@ module.exports = {
       return new DisallowedEditMode();
     } else if (!opts.allowAddEdges) {
       return new NonAnimatingEditMode({
-        adapter: utils.requireNonNull(opts.adapter),
+        adapter: utils.requireNonNull(opts, 'adapter'),
         labelSet: labelSet,
         alternateInterval: opts.alternateInterval,
       });
     } else {
       return new EditMode({
-        adapter: utils.requireNonNull(opts.adapter),
-        animator: new Animator({ actionQueue: utils.requireNonNull(opts.actionQueue) }),
+        adapter: utils.requireNonNull(opts, 'adapter'),
+        animator: new Animator({ actionQueue: utils.requireNonNull(opts, 'actionQueue') }),
         labelSet: labelSet,
         alternateInterval: opts.alternateInterval,
       });

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,11 +75,11 @@ function startingAt(array, startingItem) {
   }
 }
 
-function requireNonNull(obj) {
-  if (!obj) {
-    throw new Error('missing required object');
+function requireNonNull(container, property) {
+  if (!container[property]) {
+    throw new Error('missing required property ' + property);
   }
-  return obj;
+  return container[property];
 }
 
 function toJs(value, indentLevel) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -118,18 +118,18 @@ describe('utils', function() {
   });
 
   describe('requireNonNull', function() {
-    it('throws if the object is not present', function() {
+    it('throws if the property is not present', function() {
       try {
-        utils.requireNonNull(undefined);
+        utils.requireNonNull({}, 'a');
         fail('should have thrown');
       } catch(err) { }
       try {
-        utils.requireNonNull(null);
+        utils.requireNonNull({ 'a': null }, 'a');
         fail('should have thrown');
       } catch(err) { }
     });
-    it('returns the object if it is present', function() {
-      expect(utils.requireNonNull({ a: 'b' })).toEqual({ a: 'b' });
+    it('returns the property if it is present', function() {
+      expect(utils.requireNonNull({ a: 'b' }, 'a')).toEqual('b');
     });
   });
 


### PR DESCRIPTION
It's often hard to debug what property is missing. Including the
expected name in the `requireNonNull` will make that much easier.